### PR TITLE
Fix FLOPs calculation script to use batch size 1

### DIFF
--- a/lmnet/executor/profile_model.py
+++ b/lmnet/executor/profile_model.py
@@ -181,6 +181,10 @@ def run(experiment_id, restore_path, config_file, bit, unquant_layers):
         environment.init(experiment_id)
         config = config_util.load(config_file)
 
+    config.BATCH_SIZE = 1
+    config.NETWORK.BATCH_SIZE = 1
+    config.DATASET.BATCH_SIZE = 1
+
     executor.init_logging(config)
     config_util.display(config)
 


### PR DESCRIPTION
Fix FLOPs calculation script `lmnet/executor/profile_model.py` to use batch size 1.


# How it works
```
$ cd lmnet
$ docker-compose -p lmnet run --rm tensorflow python3 executor/profile_model.py -c configs/core/classification/lmnet_v1_cifar10.py
$ cat saved/profile/LmnetV1_profile.md
```

| Name | Param | Size (MB) | 32 bits Quant Size (MB) | Flops (M) |
| :-- | --: | --: | --: | --: |
| **total** | **717226** | **2.736** | **2.736** | **267.08005** |
| **conv1** | **928** | **0.00354** | **0.00354** | **1.76947** |
| &nbsp;&nbsp;conv1/BatchNorm | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv1/BatchNorm/beta | 32 | 0.00012 | 0.00012 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv1/BatchNorm/gamma | 32 | 0.00012 | 0.00012 | - |
| &nbsp;&nbsp;conv1/conv2d | 864 | 0.0033 | 0.0033 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv1/conv2d/kernel | 864 | 0.0033 | 0.0033 | - |
| **conv2** | **18560** | **0.0708** | **0.0708** | **37.74874** |
| &nbsp;&nbsp;conv2/BatchNorm | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv2/BatchNorm/beta | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv2/BatchNorm/gamma | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;conv2/conv2d | 18432 | 0.07031 | 0.07031 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv2/conv2d/kernel | 18432 | 0.07031 | 0.07031 | - |
| **conv3** | **295168** | **1.12598** | **1.12598** | **150.99494** |
| &nbsp;&nbsp;conv3/BatchNorm | 256 | 0.00098 | 0.00098 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv3/BatchNorm/beta | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv3/BatchNorm/gamma | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;conv3/conv2d | 294912 | 1.125 | 1.125 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv3/conv2d/kernel | 294912 | 1.125 | 1.125 | - |
| **conv4** | **73856** | **0.28174** | **0.28174** | **37.74874** |
| &nbsp;&nbsp;conv4/BatchNorm | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv4/BatchNorm/beta | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv4/BatchNorm/gamma | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;conv4/conv2d | 73728 | 0.28125 | 0.28125 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv4/conv2d/kernel | 73728 | 0.28125 | 0.28125 | - |
| **conv5** | **295168** | **1.12598** | **1.12598** | **37.74874** |
| &nbsp;&nbsp;conv5/BatchNorm | 256 | 0.00098 | 0.00098 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv5/BatchNorm/beta | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv5/BatchNorm/gamma | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;conv5/conv2d | 294912 | 1.125 | 1.125 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv5/conv2d/kernel | 294912 | 1.125 | 1.125 | - |
| **conv6** | **32896** | **0.12549** | **0.12549** | **1.04858** |
| &nbsp;&nbsp;conv6/BatchNorm | 128 | 0.00049 | 0.00049 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv6/BatchNorm/beta | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv6/BatchNorm/gamma | 64 | 0.00024 | 0.00024 | - |
| &nbsp;&nbsp;conv6/conv2d | 32768 | 0.125 | 0.125 | - |
| &nbsp;&nbsp;&nbsp;&nbsp;conv6/conv2d/kernel | 32768 | 0.125 | 0.125 | - |
| **conv7** | **650** | **0.00248** | **0.00248** | **0.02064** |
| &nbsp;&nbsp;conv7/bias | 10 | 4e-05 | 4e-05 | - |
| &nbsp;&nbsp;conv7/kernel | 640 | 0.00244 | 0.00244 | - |
| **pool7** | **-** | **-** | **-** | **0.00016** |
| **Softmax** | **-** | **-** | **-** | **5e-05** |




# Manually test
I calculate flops each layers.
```
(32 * 32 * 3 * 32 * 3 * 3 * 2) \ # conv1 -> 1769472
+ (32 * 32 * 32* 64 * 3 * 3 * 2) \ # conv2 -> 37748736
+ (16 * 16 * 256 * 128 * 3 * 3 * 2) \ # conv3 -> 150994944
+ (16 * 16 * 128 * 64 * 3 * 3 * 2) \ # conv4 -> 37748736
+ (8 * 8 * 256 * 128 * 3 * 3 * 2) \ # conv5 -> 37748736
+ (4 * 4 * 512 * 64 * 1 * 1 * 2) \ # conv6 -> 1048576
+ (4 * 4 * 64 * 10 * 1 * 1 * 2) \ # conv7 -> 20480
+ (4 * 4 * 10) \ # conv7 bias addd -> 160
+ (2 * 2 * 10 * 2 * 2)  # global avg poo -> 160

-> 267080000
```
The result of manually `267080000` and script `267.08005`[m]  is almost the same.




