### PR TITLE
add max_steps option in blueoil config file

### DIFF
--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -136,7 +136,6 @@ def _blueoil_to_lmnet(blueoil_config):
 
     # trainer
     batch_size = blueoil_config["trainer"]["batch_size"]
-    max_epochs = blueoil_config["trainer"]["epochs"]
 
     # common
     image_size = blueoil_config["common"]["image_size"]
@@ -152,12 +151,20 @@ def _blueoil_to_lmnet(blueoil_config):
         "dataset_class_property": dataset_class_property,
 
         "batch_size": batch_size,
-        "max_epochs": max_epochs,
-
+        "max_epochs": "",
+        "max_steps": "",
+        
         "image_size": image_size,
 
         "dataset": dataset,
     }
+    
+    # max_epochs or max_steps
+    if "steps" in blueoil_config["trainer"].keys():
+        config["max_steps"] = blueoil_config["trainer"]["steps"]
+    elif "epochs" in blueoil_config["trainer"].keys():
+        config["max_epochs"] = blueoil_config["trainer"]["epochs"]
+
 
     # merge dict
     lmnet_config = default_lmnet_config.copy()

--- a/blueoil/templates/lmnet/classification.tpl.py
+++ b/blueoil/templates/lmnet/classification.tpl.py
@@ -52,7 +52,11 @@ TASK = Tasks.CLASSIFICATION
 # In order to get instance property `classes`, instantiate DATASET_CLASS.
 CLASSES = DATASET_CLASS(subset="train", batch_size=1).classes
 
+{% if max_epochs %}
 MAX_EPOCHS = {{max_epochs}}
+{% elif max_steps %}
+MAX_STEPS = {{max_steps}}
+{% endif %}
 SAVE_STEPS = {{save_steps}}
 TEST_STEPS = {{test_steps}}
 SUMMARISE_STEPS = {{summarise_steps}}

--- a/blueoil/templates/lmnet/object_detection.tpl.py
+++ b/blueoil/templates/lmnet/object_detection.tpl.py
@@ -56,7 +56,11 @@ TASK = Tasks.OBJECT_DETECTION
 # In order to get instance property `classes`, instantiate DATASET_CLASS.
 CLASSES = DATASET_CLASS(subset="train", batch_size=1).classes
 
+{% if max_epochs %}
 MAX_EPOCHS = {{max_epochs}}
+{% elif max_steps %}
+MAX_STEPS = {{max_steps}}
+{% endif %}
 SAVE_STEPS = {{save_steps}}
 TEST_STEPS = {{test_steps}}
 SUMMARISE_STEPS = {{summarise_steps}}


### PR DESCRIPTION
Allow config file to specify the number training (max steps) instead of the number of training epochs (max epochs). 
* Config file must contain either of max steps or max epochs
* max steps option should be written as follow. (insider trainer items of config file, where it is set to 100 in the example)
  `steps: 100`

