### PR TITLE
Add CI Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ---
 
+[![Build Status](https://jenkins.blue-oil.org/job/blueoil_main/badge/icon)](https://jenkins.blue-oil.org/job/blueoil_main/)
+[![Build Status](https://jenkins.blue-oil.org/job/blueoil_lmnet/badge/icon)](https://jenkins.blue-oil.org/job/blueoil_lmnet/)
+[![CircleCI](https://circleci.com/gh/blue-oil/blueoil.svg?style=svg)](https://circleci.com/gh/blue-oil/blueoil)
+
 Blueoil provides two features.
 * Training a neural network model
 * Converting a trained model to an executable binary (or library), which utilize FPGAs for acceleration.


### PR DESCRIPTION
This PR implement #10 

### Jenkins Jobs

- [[blueoil] jenkins test](https://jenkins.blue-oil.org/job/blueoil_main/)
- [[lmnet] jenkins test](https://jenkins.blue-oil.org/job/blueoil_lmnet/)
- [dlk] jenkins test 
  - This CI server's badge is unavailable because It is installed in a private network.

### Circle CI

- https://circleci.com/gh/blue-oil/blueoil

Looks like
<img width="679" alt="2018-11-09 17 10 46" src="https://user-images.githubusercontent.com/478824/48251754-1f5f8f00-e446-11e8-9dec-4dd78d58bec6.png">
