### PR TITLE
modify asm for portability

### DIFF
--- a/dlk/python/dlk/templates/src/pack2b_neonv7.S
+++ b/dlk/python/dlk/templates/src/pack2b_neonv7.S
@@ -20,6 +20,7 @@ limitations under the License.
 
 	.thumb
 	.thumb_func
+	.syntax unified
 	.global pack2bits
 pack2bits:
 	pld		[r0]
@@ -96,7 +97,7 @@ pack2bits:
 	vorr		d21, d21, d19
 
 	vst2.32		{d20-d21}, [r1]!
-	sub		r2, r2, #64
+	subs		r2, #64
 	bgt		1b
 
 	bx		lr


### PR DESCRIPTION
To enable LLVM compilation, modified .S file with no output's change.