### PR TITLE
Delete max_steps from blueoil config

### DIFF
--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -136,6 +136,7 @@ def _blueoil_to_lmnet(blueoil_config):
     batch_size = blueoil_config["trainer"]["batch_size"]
     initial_learning_rate = blueoil_config["trainer"]["initial_learning_rate"]
     learning_rate_setting = blueoil_config["trainer"]["learning_rate_setting"]
+    max_epochs = blueoil_config["trainer"]["epochs"]
 
     # common
     image_size = blueoil_config["common"]["image_size"]
@@ -165,8 +166,7 @@ def _blueoil_to_lmnet(blueoil_config):
         "dataset_class_property": dataset_class_property,
 
         "batch_size": batch_size,
-        "max_epochs": "",
-        "max_steps": "",
+        "max_epochs": max_epochs,
         "initial_learning_rate": initial_learning_rate,
         "learning_rate_setting": learning_rate_setting,
 
@@ -177,12 +177,6 @@ def _blueoil_to_lmnet(blueoil_config):
         "dataset": dataset,
         "data_augmentation": data_augmentation
     }
-
-    # max_epochs or max_steps
-    if "steps" in blueoil_config["trainer"].keys():
-        config["max_steps"] = blueoil_config["trainer"]["steps"]
-    elif "epochs" in blueoil_config["trainer"].keys():
-        config["max_epochs"] = blueoil_config["trainer"]["epochs"]
 
     # merge dict
     lmnet_config = default_lmnet_config.copy()

--- a/blueoil/templates/lmnet/classification.tpl.py
+++ b/blueoil/templates/lmnet/classification.tpl.py
@@ -49,11 +49,7 @@ dataset_obj = DATASET_CLASS(subset="train", batch_size=1)
 CLASSES = dataset_obj.classes
 step_per_epoch = float(dataset_obj.num_per_epoch)/BATCH_SIZE
 
-{% if max_epochs -%}
 MAX_EPOCHS = {{max_epochs}}
-{%- elif max_steps -%}
-MAX_STEPS = {{max_steps}}
-{%- endif %}
 SAVE_STEPS = {{save_steps}}
 TEST_STEPS = {{test_steps}}
 SUMMARISE_STEPS = {{summarise_steps}}

--- a/blueoil/templates/lmnet/object_detection.tpl.py
+++ b/blueoil/templates/lmnet/object_detection.tpl.py
@@ -54,11 +54,7 @@ dataset_obj = DATASET_CLASS(subset="train", batch_size=1)
 CLASSES = dataset_obj.classes
 step_per_epoch = float(dataset_obj.num_per_epoch)/BATCH_SIZE
 
-{% if max_epochs -%}
 MAX_EPOCHS = {{max_epochs}}
-{%- elif max_steps -%}
-MAX_STEPS = {{max_steps}}
-{%- endif %}
 SAVE_STEPS = {{save_steps}}
 TEST_STEPS = {{test_steps}}
 SUMMARISE_STEPS = {{summarise_steps}}


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
Delete trainer.max_steps from blueoil config yml.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
No More `max_steps` be used in Delta-Lite, Just delete `max_steps` from blueoil config yml.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Delete handling source code from
* blueoil/generate_lmnet_config.py
* blueoil/templates/lmnet/classification.tpl.py
* blueoil/templates/lmnet/object_detection.tpl.py

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
I verified that `blueoil.sh train ...yml` with this config, didn't raise error.

```
# supported task types are 'classification', 'object_detection' and 'semantic_segmentation'.
task_type: classification

network_name: LmnetV1Quantize

dataset:
  format: Caltech101
  train_path: lmnet/tests/fixtures/datasets/dummy_classification/
  test_path:

trainer:
  batch_size: 10
  epochs: 10
# supported 'learning_rate_setting' is 'tune1', 'tune2', 'tune3', 'fixed'.
#   'tune1' is 2 times decay, learning rate reduce to 1/10 on epoch/2 and epoch-1.
#   'tune2' is 3 times decay, learning rate reduce to 1/10 on epoch/3 and epoch*2/3 and epoch-1.
#   'tune3' is warmup and 3 times decay, warmup learning rate 1/1000 in 1 epoch, then train same as 'tune2'.
#   'fixed' is constant learning rate.
  learning_rate_setting: tune1
  initial_learning_rate: 0.001

network:
  quantize_first_convolution: no

common:
  image_size:
    - 128  # height
    - 128  # width

  # set pretrain model name. currently, this feature is not supported, always ignored.
  pretrain_model: false

  # enable dataset prefetch, set false if weired problem happens
  dataset_prefetch: true

  data_augmentation:
    - FlipLeftRight:
        - probability: 0.5
    - Hue:
        - value: (-10, 10)
```

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
