### PR TITLE
Add path to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,8 @@
 __pycache__/
 
 # project
-./saved/
+saved/
+*/saved/
 dataset/
 config/
 tmp/

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@
 __pycache__/
 
 # project
-*/saved/
+./saved/
 dataset/
 config/
 tmp/


### PR DESCRIPTION
Current .dockerignore include `*/saved/`. It's used when lmnet run.
In this PR, `saved/` is added to dockerignore because `blueoil.sh` use `saved/` to save checkpoints as default.

## Description

Before

```
$ ./docker_build.sh 
Sending build context to Docker daemon  8.524GB
```

After

```
$ ./docker_build.sh
Sending build context to Docker daemon  270.4MB
```

## How has this been tested?

Rebuild Docker Image and run blueoil.sh init, train, convert.

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

