### PR TITLE
bounding boxes coordinate fixing in object detection augmentor

### DIFF
--- a/blueoil/templates/lmnet/object_detection.tpl.py
+++ b/blueoil/templates/lmnet/object_detection.tpl.py
@@ -30,6 +30,8 @@ from lmnet.post_processor import (
     NMS,
 )
 from lmnet.data_augmentor import (
+    Crop,
+    Pad,
     Brightness,
     Color,
     Contrast,
@@ -134,6 +136,7 @@ DATASET.BATCH_SIZE = BATCH_SIZE
 DATASET.DATA_FORMAT = DATA_FORMAT
 DATASET.PRE_PROCESSOR = PRE_PROCESSOR
 DATASET.AUGMENTOR = Sequence([
+    Pad(4),
     FlipLeftRight(is_bounding_box=True),
     Brightness((0.75, 1.25)),
     Color((0.75, 1.25)),

--- a/blueoil/templates/lmnet/object_detection.tpl.py
+++ b/blueoil/templates/lmnet/object_detection.tpl.py
@@ -30,12 +30,12 @@ from lmnet.post_processor import (
     NMS,
 )
 from lmnet.data_augmentor import (
-    Crop,
     Pad,
     Brightness,
     Color,
     Contrast,
     FlipLeftRight,
+    FlipTopBottom,
     Hue,
     SSDRandomCrop,
 )
@@ -136,8 +136,9 @@ DATASET.BATCH_SIZE = BATCH_SIZE
 DATASET.DATA_FORMAT = DATA_FORMAT
 DATASET.PRE_PROCESSOR = PRE_PROCESSOR
 DATASET.AUGMENTOR = Sequence([
-    Pad(4),
+    Pad(300),
     FlipLeftRight(is_bounding_box=True),
+    FlipTopBottom(is_bounding_box=True),
     Brightness((0.75, 1.25)),
     Color((0.75, 1.25)),
     Contrast((0.75, 1.25)),

--- a/lmnet/lmnet/data_augmentor.py
+++ b/lmnet/lmnet/data_augmentor.py
@@ -514,7 +514,7 @@ class Pad(data_processor.Processor):
         self.left, self.top, self.right, self.bottom = left, top, right, bottom
         self.fill = 0
 
-    def __call__(self, image, mask=None, **kwargs):
+    def __call__(self, image, mask=None, gt_boxes=None, **kwargs):
         """
         Args:
             image (np.ndarray): a image. shape is [height, width, channel]
@@ -542,7 +542,10 @@ class Pad(data_processor.Processor):
                 raise RuntimeError('Number of dims in mask should be 2 or 3 but get {}.'.format(np.ndim(mask)))
             mask = result_mask
 
-        return dict({'image': result_image, 'mask': mask}, **kwargs)
+        gt_boxes[:,0] = gt_boxes[:,0]+self.left
+        gt_boxes[:,1] = gt_boxes[:,1]+self.top
+
+        return dict({'image': result_image, 'mask': mask, 'gt_boxes':gt_boxes}, **kwargs)
 
 
 class RandomPatchCut(data_processor.Processor):


### PR DESCRIPTION
Some augmentors edit the images without modifying the coordinate of bounding boxes (gt_boxes variables), which is reported by [this issue](https://github.com/blue-oil/blueoil/issues/60).
This pull request changes the coordinate of bounding boxes for those augmentors.

## Motivation and Context
Editing images without changing coordinate of bounding boxes results in incorrect data label for training data and affects the accuracy of object detection model

## Description
Edit those classes (only `Pad` in this step) to accept `gt_boxes` as an input,
modify the coordinate of `gt_boxes` according to the way images are padded,
and return the correct information of `gt_boxes`.

## How has this been tested?
I tested it using the same setting as Blueoil's object detection tutorial, which is detecting human face and hand using a part of OpenImagesV4 dataset.
I implemented on server25.

## Screenshots (if appropriate):
The example of bounding boxes in augmented image is as follows.
<img width="370" alt="screen shot 2019-01-11 at 16 43 47" src="https://user-images.githubusercontent.com/43122237/51020620-70b10980-15c2-11e9-9576-4c87073ba115.png">

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.