### PR TITLE
The implementation of sqrt was actually rsqrt

### DIFF
--- a/dlk/python/dlk/templates/src/func/sqrt.cpp
+++ b/dlk/python/dlk/templates/src/func/sqrt.cpp
@@ -20,10 +20,10 @@ limitations under the License.
 #include "time_measurement.h"
 
 void func_Sqrt(T_FLOAT input[], T_FLOAT output[], T_UINT out_depth) {
-  Measurement::Start("Rsqrt");
+  Measurement::Start("sqrt");
 
   for (T_UINT i = 0; i < out_depth; i++)
-    output[i] = 1.0 / std::sqrt(input[i]);
+    output[i] = std::sqrt(input[i]);
 
   Measurement::Stop();
 }


### PR DESCRIPTION
## Motivation and Context
In original code, sqrt func was buggy (sqrt was rsqrt).
So fix it.

related to #115 

## Description
Only make 1/sqrt(rsqrt) to sqrt.

## How has this been tested?
run on ARM / FPGA / X86

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)