### PR TITLE
Fix non-existing path

### DIFF
--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -394,7 +394,7 @@ def run(network, dataset, config_file, experiment_id, recreate):
     "-c",
     "--config_file",
     help="config file path for this training",
-    default=os.path.join("configs", "example.py"),
+    default=os.path.join("configs", "example", "classification.py"),
     required=True,
 )
 @click.option(


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
It has been requested in previous lmnet project, and moved on to blueoil.(https://github.com/LeapMind/lmnet/pull/269)
Fix default config file path which is not existing anymore.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
Fix error when executing train.py without defining config file.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
