### PR TITLE
[WIP] Improve qconv (generic version)

### DIFF
--- a/dlk/python/dlk/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
+++ b/dlk/python/dlk/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
@@ -128,15 +128,12 @@ void QuantizedConv2DKn2Row(QUANTIZED_NOT_PACKED input[],
       p.device_output_buf, oc, ih * iw);
 
   if (kh == kw && kw == 3) {
-    unsigned bufsize = oc * kh * kw * ih * iw;
-    BIN_CONV_OUTPUT *kn2row_buf = new BIN_CONV_OUTPUT[bufsize]();
-    std::memset(kn2row_buf, 0, bufsize);
+    static BIN_CONV_OUTPUT kn2row_buf[MAX_SIZE_KN2ROW_BUFFER_PER_LAYER];
     auto buf_ = MatrixView<BIN_CONV_OUTPUT, MatrixOrder::ColMajor>(
         kn2row_buf, oc * kh * kw, ih * iw);
 
     quantized_matrix_multiplication(kernel_, input_, buf_);
     matrix_shift_add(buf_, output_, p.normal_conv_params);
-    delete[] kn2row_buf;
   } else if (kh == kw && kw == 1) {
     quantized_matrix_multiplication(kernel_, input_, output_);
   } else {


### PR DESCRIPTION
## Motivation and Context
I found out that MAX_SIZE_KN2ROW_BUFFER_PER_LAYER can be used in generic qconv.
So, prepare the static region in advance and improve performance.

## Description
modify not to reallocate everytime and reuse static memory.

zero clear also probably not needed, because matmul is executed after that (later confirm in detail).

modified：
　src/func/impl/generic/quantized_conv2d_kn2row.cpp

## How has this been tested?
run on X86(use generic pattern)

(and later, confirm whether zero clear is needed or not.)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)