### PR TITLE
Prepare static region for conv2d

### DIFF
--- a/dlk/python/dlk/templates/src/func/conv2d.cpp
+++ b/dlk/python/dlk/templates/src/func/conv2d.cpp
@@ -176,8 +176,8 @@ void convolution(
     conv1x1_kn2row(input, kernels, output, p);
     return;
   } else if (p.kernel_height == 3 && p.kernel_width == 3 && p.padding == 1) {
-    int kernels_size = p.kernel_height * p.kernel_width * p.kernel_depth * p.output_channels;
-    T* kernels_hwoi = new T[kernels_size]();
+    const int KERNELS_SIZE = 3 * 3 * MAX_IN_C * MAX_IN_C;
+    static T kernels_hwoi[KERNELS_SIZE];
     ohwi_to_hwoi(kernels, kernels_hwoi, p);
     conv3x3_kn2row(input, kernels_hwoi, output, p);
     delete[] kernels_hwoi;

--- a/dlk/python/dlk/templates/src/func/conv2d.cpp
+++ b/dlk/python/dlk/templates/src/func/conv2d.cpp
@@ -176,11 +176,13 @@ void convolution(
     conv1x1_kn2row(input, kernels, output, p);
     return;
   } else if (p.kernel_height == 3 && p.kernel_width == 3 && p.padding == 1) {
-    const int KERNELS_SIZE = 3 * 3 * MAX_IN_C * MAX_IN_C;
+    const int kw = 3;
+    const int kh = 3;
+    const int MAX_OUT_C = MAX_IN_C;
+    const int KERNELS_SIZE = kw * kh * MAX_IN_C * MAX_OUT_C;
     static T kernels_hwoi[KERNELS_SIZE];
     ohwi_to_hwoi(kernels, kernels_hwoi, p);
     conv3x3_kn2row(input, kernels_hwoi, output, p);
-    delete[] kernels_hwoi;
     return;
   }
 


### PR DESCRIPTION
## Motivation and Context
kernel width and kernel height are known, and max input channel and max output channel are defined.
So by preparing static region and reusing, we can improve performance.

In addition, @n-nez -san suggested the way to pre-compute
the value of transformed value at conv2d in advance. 

## Description
MAX_IN_C (for max value for channel) is pre-defined.
kernel height and kernel width are equal to 3.

So we can know the max number of kernel size.
and remove dynamic memory allocation.

Modified：
　src/func/conv2d.cpp

## How has this been tested?
run on X86 / ARM

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)