### PR TITLE
[Semantic Segmentation] Fix failure when convert

### DIFF
--- a/lmnet/executor/export.py
+++ b/lmnet/executor/export.py
@@ -95,8 +95,7 @@ def _export(config, restore_path, image_paths):
         is_training = tf.constant(False, name="is_training")
 
         images_placeholder, _ = model.placeholderes()
-        output = model.inference(images_placeholder, is_training)
-        model.summary(output)
+        model.inference(images_placeholder, is_training)
 
         summary_op = tf.summary.merge_all()
         init_op = tf.global_variables_initializer()


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context

In `master` branch, semantic segmentation is fail to convert in `model.summary(output)` .
When convert, `model.summary(output)` is looks not needed. So, I just removed.

[Here](https://gist.github.com/iizukak/ee71e8e0128e9243ccedb386a20c6945) is the error message.

## How has this been tested?

Execute semantic segmentation convert manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
