### PR TITLE
[Semantic Segmentation] Fix run.py execution failure

### DIFF
--- a/output_template/python/lmnet/utils/output.py
+++ b/output_template/python/lmnet/utils/output.py
@@ -181,26 +181,18 @@ class ImageFromJson():
     """Create callable instance to return list of tuple (file_name, PIL image object) from prediction json."""
 
     color_maps = [
-        "#1f77b4",
-        "#aec7e8",
-        "#ff7f0e",
-        "#ffbb78",
-        "#2ca02c",
-        "#98df8a",
-        "#d62728",
-        "#ff9896",
-        "#9467bd",
-        "#c5b0d5",
-        "#8c564b",
-        "#c49c94",
-        "#e377c2",
-        "#f7b6d2",
-        "#7f7f7f",
-        "#c7c7c7",
-        "#bcbd22",
-        "#dbdb8d",
-        "#17becf",
-        "#9edae5",
+        [128, 128, 128],
+        [128, 0, 0],
+        [192, 192, 128],
+        [128, 64, 128],
+        [60, 40, 222],
+        [128, 128, 0],
+        [192, 128, 128],
+        [64, 64, 128],
+        [64, 0, 128],
+        [64, 64, 0],
+        [0, 128, 192],
+        [0, 0, 0],
     ]
 
     def __init__(self, task, classes, image_size):
@@ -261,7 +253,7 @@ class ImageFromJson():
             output_pil = PIL.Image.fromarray(output_image)
             filename_images.append((out_file, output_pil))
 
-            overlap_image = 0.5 * raw_image + output_image * 0.5
+            overlap_image = 0.2 * raw_image + output_image * 0.8
             overlap_image = overlap_image.astype(np.uint8)
             overlap = PIL.Image.fromarray(overlap_image)
 


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context

In `master` branch, semantic segmentation is fail to execute `run.py` .
the `color_maps` list should be contain RGB colors. 

[Here](https://gist.github.com/iizukak/f3a9685a95941b325e6d2765d3fe372b) is the error message.

## How has this been tested?

Execute run.py in output_template manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
