### PR TITLE
Fix dataset iterator to limit CPU and RAM usage

### DIFF
--- a/lmnet/configs/example/object_detection.py
+++ b/lmnet/configs/example/object_detection.py
@@ -136,3 +136,5 @@ DATASET.AUGMENTOR = Sequence([
     Hue((-10, 10)),
     SSDRandomCrop(min_crop_ratio=0.7),
 ])
+DATASET.ENABLE_PREFETCH = True
+DATASET.NUM_PARALLEL_PROCESS = 16

--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -40,7 +40,10 @@ def setup_dataset(config, subset, rank):
     dataset_kwargs = dict((key.lower(), val) for key, val in config.DATASET.items())
     dataset = DatasetClass(subset=subset, **dataset_kwargs)
     enable_prefetch = dataset_kwargs.pop("enable_prefetch", False)
-    return DatasetIterator(dataset, seed=rank, enable_prefetch=enable_prefetch)
+    num_parallel_process = dataset_kwargs['num_parallel_process']
+    return DatasetIterator(dataset, seed=rank,
+                           enable_prefetch=enable_prefetch,
+                           num_parallel_process=num_parallel_process)
 
 
 def start_training(config):


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
1. Running in machine with 8 core (hard-coded), I found that the dataset iterator usase all 8 core and the system becomes non-responsive for some time. It should also add CPU over head if the system has less than 8 core.
2. The queue used in `DatasetIterator` class has fixed size of 200. Large dataset with big images (e.g. 800x480) will need huge RAM to load 200 data at a time. With a lower system RAM it will use swap memory which will further decrease the performance.
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Issue : https://github.com/blue-oil/blueoil/issues/185

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
In the changes:
1. The number of process is determined by half of the available CPU or 1 in case of single core machine for dataset iterator multi processing. The number of process is kept by `self.num_proc` variable for reuse in initialization of `_MultiProcessDatasetPrefetchThread` class in  file `blueoil/lmnet/lmnet/dataset/dataset_iterator.py`.
2. A new settings `DATASET.BATCH_PRE_FETCH` has been added in config file and passed from the `train.py -> DatasetIterator` class to determine the queue size based on how many batches of data need to be prefetched. 
> Default value is set as 3

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
The code fix was tested by running training script `blueoil/lmnet/executor/train.py` manually in `lm-server-05`
## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [x] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
