### PR TITLE
Add backwards compatibility for output template model python scripts

### DIFF
--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -165,7 +165,7 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
         Inference Model filename
         (-l is deprecated please use -m instead)
     """,
-    default="../models/minimal_graph_with_shape.pb",
+    default="../models/lib/lib_fpga.so",
 )
 @click.option(
     "-c",

--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -16,6 +16,7 @@
 import numpy as np
 import click
 import os
+import sys
 
 from PIL import Image
 from lmnet.nnlib import NNLib as NNLib
@@ -174,7 +175,14 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
     help="Config file Path",
 )
 def main(input_image, model, config_file):
+    _check_deprecated_arguments()
     run_prediction(input_image, model, config_file)
+
+
+def _check_deprecated_arguments():
+    argument_list = sys.argv
+    if '-l' in argument_list:
+        print("Deprecated warning: -l is deprecated please use -m instead")
 
 
 if __name__ == "__main__":

--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -158,9 +158,14 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
 )
 @click.option(
     "-m",
+    "-l",
     "--model",
     type=click.Path(exists=True),
-    help="Inference Model filename",
+    help=u"""
+        Inference Model filename
+        (-l is deprecated please use -m instead)
+    """,
+    default="../models/minimal_graph_with_shape.pb",
 )
 @click.option(
     "-c",

--- a/output_template/python/usb_camera_demo.py
+++ b/output_template/python/usb_camera_demo.py
@@ -261,10 +261,14 @@ def run(model, config_file):
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option(
     "-m",
+    "-l",
     "--model",
     type=click.Path(exists=True),
-    help=u"Inference Model filename",
-    default="../models/lib/lib_fpga.so",
+    help=u"""
+        Inference Model filename
+        (-l is deprecated please use -m instead)
+    """,
+    default="../models/minimal_graph_with_shape.pb",
 )
 @click.option(
     "-c",

--- a/output_template/python/usb_camera_demo.py
+++ b/output_template/python/usb_camera_demo.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 import time
 import os
+import sys
 from multiprocessing import Pool
 from time import sleep
 from multiprocessing import Queue
@@ -278,7 +279,14 @@ def run(model, config_file):
     default="../models/meta.yaml",
 )
 def main(model, config_file):
+    _check_deprecated_arguments()
     run(model, config_file)
+
+
+def _check_deprecated_arguments():
+    argument_list = sys.argv
+    if '-l' in argument_list:
+        print("Deprecated warning: -l is deprecated please use -m instead")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Due to the latest update of blueoil v0.4.0 currently the python interface of `run.py` and `usb_camera_demo.py` was changed. But we need backward compatibility of the previous command.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Update `run.py` and `usb_camera_demo.py` commands to accept the `-l` parameter for the command interface. 

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
