### PR TITLE
lmnet: avoid importing entire pyplot

### DIFF
--- a/lmnet/lmnet/networks/classification/base.py
+++ b/lmnet/lmnet/networks/classification/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # =============================================================================
 import tensorflow as tf
-import matplotlib.pyplot as plt
+from matplotlib import cm
 
 from lmnet.networks.base import BaseNetwork
 
@@ -138,7 +138,7 @@ class Base(BaseNetwork):
         for i, class_name in enumerate(self.classes):
             class_heatmap = heatmap[:, :, :, i]
             indices = tf.to_int32(tf.round(class_heatmap * 255))
-            color_map = plt.cm.jet
+            color_map = cm.jet
             # Init color map for useing color lookup table(_lut).
             color_map._init()
             colors = tf.constant(color_map._lut[:, :3], dtype=tf.float32)

--- a/lmnet/lmnet/utils/json.py
+++ b/lmnet/lmnet/utils/json.py
@@ -22,7 +22,7 @@ import json
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw
-import matplotlib.pyplot as plt
+from matplotlib import cm
 
 from lmnet.common import Tasks
 
@@ -228,7 +228,7 @@ class ImageFromJson():
             masks = np.stack(masks, axis=2)
             argmax = np.argmax(masks, axis=2)
 
-            color_maps = (np.array(plt.cm.tab20.colors) * 255).tolist()
+            color_maps = (np.array(cm.tab20.colors) * 255).tolist()
 
             result = []
 
@@ -261,7 +261,7 @@ class ImageFromJson():
             draw = PIL.ImageDraw.Draw(image)
 
             predictions = result["prediction"]
-            color_maps = (np.array(plt.cm.tab20.colors) * 255).astype(np.uint8).tolist()
+            color_maps = (np.array(cm.tab20.colors) * 255).astype(np.uint8).tolist()
 
             for prediction in predictions:
                 box = prediction["box"]


### PR DESCRIPTION
pyplot pulls in a large set of dependencies (such as tkinter) that lmnet
doesn't need.