### PR TITLE
Tca support prototype

### DIFF
--- a/blueoil/blueoil_train.py
+++ b/blueoil/blueoil_train.py
@@ -43,7 +43,8 @@ def save_config_file(config_file, dest_dir):
 
     return gfile.Copy(
         config_file,
-        os.path.join(dest_dir, 'blueoil_config.yaml')
+        os.path.join(dest_dir, 'blueoil_config.yaml'),
+        overwrite=True
     )
 
 

--- a/blueoil_test.sh
+++ b/blueoil_test.sh
@@ -193,6 +193,9 @@ function additional_test(){
     @ 0 ${RUN_SCRIPT} train ${YML_CONFIG_FILE} ${OUTPUT_DIR} test_experiment
     @ 0 ls -td ${OUTPUT_DIR}/test_experiment
 
+    echo "## Specify existing EXPERIMENT_ID for re-training"
+    @ 0 ${RUN_SCRIPT} train ${YML_CONFIG_FILE} ${OUTPUT_DIR} test_experiment
+
     echo "## Specify CHECKPOINT_NO"
     @ 0 ${RUN_SCRIPT} convert ${YML_CONFIG_FILE} ${EXPERIMENT_DIR} 1
 

--- a/dlk/python/dlk/code_generater.py
+++ b/dlk/python/dlk/code_generater.py
@@ -63,7 +63,7 @@ class CodeGenerater(object):
                 # if the file's dir not exist, make it
                 utils.make_dirs([dest_file_dir_path])
 
-                if 'tpl' in path.basename(src_file_path):
+                if 'tpl' in path.basename(src_file_path) and path.basename(src_file_path)[0] != '.':
                     relative_src_file_path = str(src_file.relative_to(self.template.root_dir))
                     self.template.generate(relative_src_file_path,
                                            dest_file_dir_path)

--- a/dlk/python/dlk/core/data_types.py
+++ b/dlk/python/dlk/core/data_types.py
@@ -260,3 +260,23 @@ class QUANTIZED_NOT_PACKED(Primitive, int):
     @classmethod
     def nptype(cls):
         return np.int8
+
+
+class QUANTIZED_PACKED(Primitive, int):
+    @classmethod
+    def cpptype(cls):
+        return 'QUANTIZED_PACKED'
+
+    @classmethod
+    def nptype(cls):
+        return np.int32
+
+class QUANTIZED_PACKED_KERNEL(Primitive, int):
+    @classmethod
+    def cpptype(cls):
+        return 'QUANTIZED_PACKED_KERNEL'
+
+    @classmethod
+    def nptype(cls):
+        return np.int32
+

--- a/dlk/python/dlk/core/data_types.py
+++ b/dlk/python/dlk/core/data_types.py
@@ -269,7 +269,7 @@ class QUANTIZED_PACKED(Primitive, int):
 
     @classmethod
     def nptype(cls):
-        return np.int32
+        return np.uint32
 
 class QUANTIZED_PACKED_KERNEL(Primitive, int):
     @classmethod
@@ -278,5 +278,5 @@ class QUANTIZED_PACKED_KERNEL(Primitive, int):
 
     @classmethod
     def nptype(cls):
-        return np.int32
+        return np.uint32
 

--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -1829,7 +1829,7 @@ class Reshape(Operator):
 
     """
 
-    _input_names = ['data']
+    _input_names = ['data', 'shape']
     _output_names = ['reshaped']
 
     def __init__(self, name: str, shape: List[int], dtype: DataType, input_ops: Ops) -> None:
@@ -2764,4 +2764,240 @@ class MatMul(Operator):
                      
     @property
     def preserve_quantization(self) -> bool:
+        return False
+
+
+class Gather(Operator):
+    r"""Gather operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['x', 'out_idx']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+    @property
+    def preserve_quantization(self) -> bool:
+        return True
+
+
+class Unique(Operator):
+    r"""Unique operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['x']
+    _output_names = ['y', 'idx']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+    @property
+    def preserve_quantization(self) -> bool:
+        return True
+
+
+class Cast(Operator):
+    r"""Cast operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['x']
+    _output_names = ['y']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+    @property
+    def preserve_quantization(self) -> bool:
+        return False
+
+
+class Minimum(Operator):
+    r"""Minimum operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['x', 'y']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+    @property
+    def preserve_quantization(self) -> bool:
+        return True
+
+
+class StridedSlice(Operator):
+    r"""StridedSlice operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['input', 'begin', 'end', 'strides']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+    @property
+    def preserve_quantization(self) -> bool:
+        return False
+
+
+class Lookup(Quantizer):
+    r"""Lookup operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['input', 'lsb', 'msb']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return True
+
+    @property
+    def nbit(self) -> int:
+        return 2
+
+    @property
+    def max_v(self) -> float:
+        return 2.0
+
+
+class Prod(Operator):
+    r"""Prod operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['input', 'indices']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
+        return False
+
+
+class Shape(Operator):
+    r"""Shape operator.
+
+    Inputs
+    ------
+    input
+        The input tensor.
+
+    Outputs
+    -------
+    output
+        The output.
+
+    """
+
+    _input_names = ['input']
+    _output_names = ['output']
+
+    def _check_consistency(self) -> None:
+        super()._check_consistency()
+
+    @property
+    def is_monotonic(self) -> bool:
         return False

--- a/dlk/python/dlk/core/optimizer.py
+++ b/dlk/python/dlk/core/optimizer.py
@@ -20,83 +20,11 @@ import numpy as np
 
 from core.graph import Graph
 from core.graph_pattern_matching import get_nodes_in_branch, sort_graph
-from core.operators import Constant, Operator, Conv
-from core.data_types import PackedUint32, QUANTIZED_NOT_PACKED
+from core.operators import Constant, Operator, Conv, Lookup
+from core.data_types import Uint32, Int32, QUANTIZED_NOT_PACKED, QUANTIZED_PACKED, PackedUint32, QUANTIZED_PACKED_KERNEL
 from typing import cast, List, Any
 from collections import defaultdict
 from modules.packer import Packer
-
-
-def _transpose_kernels(kernel_data: np.ndarray,
-                       oh: int,
-                       ow: int,
-                       od: int,
-                       kh: int,
-                       kw: int,
-                       kd: int) -> List[int]:
-    """Calculates and prepares the transposed kernel data in advance.
-
-    Parameters
-    ----------
-    kernel_data : np.ndarray
-        The input data.
-    oh : int
-        output height
-    ow : int
-        output width
-    od : int
-        output depth
-    kh : int
-        kernel height
-    kw : int
-        kernel width
-    kd : int
-        kernel depth
-    """
-    NUM_PE = 16
-    NBIT_QDYPE = 32
-    MAX_NBIT_QINPUT = 2
-    MAX_NBIT_KERNEL = 1
-    num_qinput_per_qword = int(NBIT_QDYPE / MAX_NBIT_QINPUT)
-    num_qkernel_per_qword = int(NBIT_QDYPE / MAX_NBIT_KERNEL)
-    k_c_by_word = int((kd + (num_qkernel_per_qword - 1)) / num_qkernel_per_qword)
-    k_n_aligned_with_num_pe = int(((od + (NUM_PE - 1)) / NUM_PE) * NUM_PE)
-    if od < NUM_PE:
-        k_size = k_n_aligned_with_num_pe * kh * kw * k_c_by_word
-    else:
-        k_size = od * kh * kw * k_c_by_word
-
-    flatten_value = []
-    for elem in kernel_data:
-        flatten_value.extend(elem)
-    while len(flatten_value) != k_size:
-        flatten_value.extend("0")
-
-    copy_value = [0] * k_size
-    for i in range(od * kh * kw * k_c_by_word):
-        copy_value[i] = flatten_value[i]
-
-    transposed_values = [0] * k_size
-    if (od < NUM_PE):
-        kn_out = int(k_n_aligned_with_num_pe / NUM_PE)
-    else:
-        kn_out = int(od / NUM_PE)
-    idx_src = 0
-
-    for no in range(kn_out):
-        for ni in range(NUM_PE):
-            for h in range(kh):
-                for w in range(kw):
-                    for c in range(k_c_by_word):
-                        idx_dst = no * (kh * kw * k_c_by_word * NUM_PE)
-                        idx_dst += h * (kw * k_c_by_word * NUM_PE)
-                        idx_dst += w * (k_c_by_word * NUM_PE)
-                        idx_dst += c * (NUM_PE)
-                        idx_dst += ni
-                        transposed_values[idx_dst] = copy_value[idx_src]
-                        idx_src += 1
-
-    return transposed_values
 
 
 def pass_remove_identities(graph: Graph) -> None:
@@ -251,7 +179,8 @@ def pass_propagate_quantization_details_into_conv(graph: Graph) -> None:
     qtypes = [
         'QTZ_binary_mean_scaling',
         'QTZ_linear_mid_tread_half',
-        'QTZ_binary_channel_wise_mean_scaling'
+        'QTZ_binary_channel_wise_mean_scaling',
+        'Lookup'
     ]
 
     quant_details = defaultdict(list)
@@ -385,9 +314,9 @@ def pass_compute_thresholds(graph: Graph) -> None:
         for c in range(ch):
             threshold_table[c, -1] = 1 \
                 if np.all(threshold_table[c, 1:-1] > threshold_table[c, :-2], axis=0) else -1
-            # Applying the magic number
             if np.all(threshold_table[c, 1:-1] == threshold_table[c, :-2], axis=0):
-                threshold_table[c, -1] = 2
+                threshold_table[c, -1] = 1
+                threshold_table[c, 1:-1] = max_th_value
 
         # Put the thresholds into list
         conv_node.thresholds = threshold_table.flatten().tolist()
@@ -431,6 +360,7 @@ def pass_pack_weights(graph: Graph) -> None:
     weight_bitwidth = 1
     packer = Packer(weight_bitwidth, word_size)
     to_be_removed = []
+    b = 32
 
     for m in exec_list:
         conv_node = m
@@ -446,23 +376,50 @@ def pass_pack_weights(graph: Graph) -> None:
 
         # Quantize the weights
         weight_quantizer.run_forward()
+
+        def pad_to_multiple_of_b(tensor, axis, b):
+            shape = list(tensor.shape)
+            pad = (((shape[axis] + b - 1) // b) * b) - shape[axis]
+            shape[axis] = pad
+            return np.zeros(shape) if pad else None
+
+        padded_data = np.copy(weight_quantizer.data)
+
+        for axis in [0, 3]:
+            pad_tensor = pad_to_multiple_of_b(padded_data, axis, b)
+            if pad_tensor is not None:
+                padded_data = np.append(padded_data, pad_tensor, axis=axis)
+
+        tca_output = np.copy(padded_data)
+        oc, kh, kw, kd = padded_data.shape[:]
+        padded_data = padded_data.flatten()
+        tca_output = tca_output.flatten()
+
+        out_index = 0
+        for g in range(oc // b):
+            for p in range(kd // b):
+                for h in range(kh):
+                    for w in range(kw):
+                        for o in range(b):
+                            for d in range(b):
+                                idx = g * (kw * kh * kd * b) + p * b + h * (kw * kd) + w * kd + o * (kw * kh * kd) + d
+                                tca_output[out_index] = padded_data[idx]
+                                out_index += 1
+
         op_data = weight_quantizer.binarizer(weight_quantizer.data)
         data = packer.run(op_data.astype(np.float32), weight_quantizer.dimension)
 
+        tca_binarized_data = weight_quantizer.binarizer(tca_output)
+        tca_packed_data = packer.run(tca_binarized_data.astype(np.float32), weight_quantizer.dimension)
+
         # Create the new constant with the quantized weights
-        oh = conv_node.height
-        ow = conv_node.width
-        od = conv_node.channel
-        kh = conv_node.kernel_height
-        kw = conv_node.kernel_width
-        kd = conv_node.input_ops['X'].channel
         quantized_constant = Constant(
             weight_quantizer.name + '_new',
             PackedUint32(),
             data,
             packed=True,
             actual_shape=weight_quantizer.shape,
-            transposed_data=_transpose_kernels(data, oh, ow, od, kh, kw, kd)
+            transposed_data=[(~k) & ((0x1 << 32) - 1) for k in tca_packed_data.flatten()]
         )
 
         # get nodes to be removed after being disconnected
@@ -505,12 +462,12 @@ def pass_quantize_convolutions(graph: Graph) -> None:
 
         # change the output data type of the convolution if thresholds are available
         if conv_node.has_thresholds:
-            conv_node.dtype = QUANTIZED_NOT_PACKED()
+            conv_node.dtype = QUANTIZED_PACKED()
 
         # change the output data type of the quantizers
         conv_node.quantizer.dtype = PackedUint32()
         for qtz in conv_node.a_quantizer:
-            qtz.dtype = QUANTIZED_NOT_PACKED()
+            qtz.dtype = QUANTIZED_PACKED()
 
 
 def pass_propagate_datatypes(graph) -> None:
@@ -554,3 +511,82 @@ def pass_propagate_output_type_backward(graph: Graph) -> None:
     output_node = exec_list[-1]
     output_type = output_node.dtype
     output_dtype_changer(output_node, output_type)
+
+
+def pass_lookup(graph: Graph) -> None:
+    """Lookup.
+
+    Parameters
+    ----------
+    graph : Graph
+        The input graph. It will be modified in-place.
+    """
+    quantization_types = [
+        'QTZ_binary_mean_scaling',
+        'QTZ_linear_mid_tread_half',
+        'QTZ_binary_channel_wise_mean_scaling'
+    ]
+
+    to_be_removed = []
+    exec_list = [n for n in sort_graph(graph) if n.op_type in quantization_types]
+    placeholder = [n for n in sort_graph(graph) if n.op_type in 'Input']
+
+    for m in exec_list:
+        quantizer = m
+
+        p1 = quantizer.input_nodes[0]
+        if p1.op_type != 'Reshape':
+            continue
+        p2 = p1.input_nodes[0]
+        if p2.op_type != 'Reshape':
+            continue
+        p3 = p2.input_nodes[0]
+        if p3.op_type != 'Gather':
+            continue
+        p4 = p3.input_nodes[0]
+        if p4.op_type != 'Gather':
+            continue
+        gather_params = p4.input_nodes[0]
+        if gather_params.rank != 2 or gather_params.shape[0] != 256:
+            continue
+
+        params = gather_params.data
+        data = {'data': params}
+        qtz_data = quantizer.run(**data)['data']
+
+        word_size = 32
+        lu_bitwidth = quantizer.nbit
+        packer = Packer(lu_bitwidth, word_size)
+
+        lsb = np.zeros((256,), np.uint32)
+        msb = np.zeros((256,), np.uint32)
+
+        idx = 0
+        for p in qtz_data:
+            data = packer.run(p.astype(np.float32), p.shape).flatten()
+            # lsb[idx] = data[0] & 0x0000FFFF
+            # msb[idx] = data[1] & 0x0000FFFF
+            lsb[idx] = data[0] & 0x000003FF
+            msb[idx] = data[1] & 0x000003FF
+
+            idx += 1
+
+        pe_lsb = Constant('pe_lsb_new', QUANTIZED_PACKED_KERNEL(), lsb)
+        pe_msb = Constant('pe_msb_new', QUANTIZED_PACKED_KERNEL(), msb)
+
+        pe = Lookup('Lookup', quantizer.shape, QUANTIZED_PACKED(),
+                            {'input': placeholder[0], 'lsb': pe_lsb, 'msb': pe_msb})
+
+        get_nodes_in_branch(quantizer, placeholder[0], to_be_removed)
+        placeholder[0].remove_output('output')
+        placeholder[0].add_output('output', pe)
+        pe.add_outputs(quantizer.output_ops)
+
+        conv = quantizer.output_op_list[0]
+        conv.add_input('X', pe)
+        graph.add_op(pe_lsb)
+        graph.add_op(pe_msb)
+        graph.add_op(pe)
+
+    for op in to_be_removed:
+        graph.remove_op(op)

--- a/dlk/python/dlk/core/view.py
+++ b/dlk/python/dlk/core/view.py
@@ -161,6 +161,8 @@ class View(object):
                     binConv2D_struct.thresholds = {threshold};
                     binConv2D_struct.n_bit = {nbit_aqtz};
                     binConv2D_struct.max_value = {max_value};
+                    binConv2D_struct.debug_name = "{op.name}";
+                    binConv2D_struct.device_kernel_phys_addr = KERNEL_ADDR + {op.name}_kernel_offset;
 
                     {conv_func}({inputs_string}, {op.name}, scaling_factors::{op.name}, binConv2D_struct);
                     """
@@ -740,6 +742,14 @@ class View(object):
                 func_Matmul({inputs_string}, {op.name}, {ia_size}, {shape_string});
                 """
             )
+        elif self.op.op_type == 'Lookup':
+            if len(input_ops) != 3:
+                self.raise_invalid_args_exception(op, input_ops, output_ops)
+
+            inputs_string = self.inputs_to_string(input_ops)
+            shape_string = self.shape_to_string(op.shape)
+
+            return self.format_string(f"""func_Lookup({inputs_string}, {op.name}, {shape_string});""")
 
     def render_alias(self, op, input_ops, output_ops):
         if len(input_ops) != 1:

--- a/dlk/python/dlk/modules/packer.py
+++ b/dlk/python/dlk/modules/packer.py
@@ -128,10 +128,10 @@ class Packer(BaseModule):
         output_tensor : np.ndarray
             Quantized tensor.
         """
-        nk = data_format.index('N') if 'N' in data_format \
-            else data_format.index('O')
+        # nk = data_format.index('N') if 'N' in data_format \
+        #     else data_format.index('O')
 
-        number_of_kernels = tensor.shape[nk]
+        number_of_kernels = 1  # tensor.shape[nk]
         output_size = self.lib.packer_get_output_size(self.packer,
                                                       tensor.size,
                                                       number_of_kernels)

--- a/dlk/python/dlk/plugins/tf.py
+++ b/dlk/python/dlk/plugins/tf.py
@@ -32,11 +32,11 @@ from core.operators import Operator, Conv, Identity, QTZ_binary_mean_scaling, \
     BatchNormalization, QTZ_linear_mid_tread_half, Add, \
     MaxPool, AveragePool, Reshape, Softmax, Transpose, Relu, SpaceToDepth, \
     Mul, QTZ_binary_channel_wise_mean_scaling, ConcatOnDepth, Maximum, DepthToSpace, \
-    Split, Pad, MatMul, LeakyRelu
+    Split, Pad, MatMul, Gather, Unique, Cast, Minimum, StridedSlice, Prod, Shape, LeakyRelu
 
 DLK_DTYPE_MAP: Dict[str, Optional[DataType]] = {
     # any
-    'DT_INVALID': None,
+    'DT_INVALID': Float32,
     # primitives
     'DT_FLOAT': Float32(),
     'DT_INT32': Int32(),
@@ -517,7 +517,7 @@ class Importer(object):
             elif op_type == 'Gemm':
                 return out_format, ['', '', '']  # three inputs
 
-            elif op_type in ['Add', 'Mul', 'Maximum', 'MatMul']:
+            elif op_type in ['Add', 'Mul', 'Maximum', 'MatMul', 'Gather', 'Minimum', 'Reshape', 'Prod']:
                 return out_format, ['', '']  # two inputs
 
             elif op_type in ['Split', 'Pad']:
@@ -525,6 +525,9 @@ class Importer(object):
 
             elif op_type == 'ConcatOnDepth':
                 return out_format, [in_format, in_format, in_format, in_format, in_format, '']
+
+            elif op_type == 'StridedSlice':
+                return out_format, ['', '', '', '']  # four inputs
 
             else:
                 return out_format, [out_format]
@@ -607,7 +610,6 @@ class Importer(object):
 
         # Create new op accordingly for the tf ops
         new_op: Operator
-
         def get_inputs(cdef: Type[Operator], current_node: Any) -> Dict[str, Operator]:
             input_names = cdef.input_names
             in_ops: Dict[str, Operator] = {}
@@ -632,6 +634,9 @@ class Importer(object):
 
         shape: List[int] = list(map(int, node.get_shape()))
         dtype = infer_dtype()
+
+        if True in (d < 0 for d in shape):
+            shape = [1]
 
         # debug msgs
         # print(node.op_type, ' name:', node.name, ' shape:', shape, ' inputs:', node.inputs)
@@ -1051,6 +1056,90 @@ class Importer(object):
                 shape = infer_shape(attributes)
 
             new_op = MatMul(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Gather':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Gather(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Unique':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Unique(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Cast':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Cast(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Minimum':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Minimum(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'StridedSlice':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = StridedSlice(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Prod':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Prod(
+                node.name,
+                shape,
+                dtype,
+                input_ops,
+                dimension_format=current_format,
+            )
+        elif op_type == 'Shape':
+            if not shape:
+                attributes = {}
+                shape = infer_shape(attributes)
+
+            new_op = Shape(
                 node.name,
                 shape,
                 dtype,

--- a/dlk/python/dlk/scripts/generate_project.py
+++ b/dlk/python/dlk/scripts/generate_project.py
@@ -31,7 +31,8 @@ from code_generater import CodeGenerater
 from frontend import TensorFlowIO
 from core.optimizer import pass_remove_identities, pass_transpose, pass_constant_folding, \
     pass_propagate_quantization_details_into_conv, pass_compute_thresholds, pass_pack_weights, \
-    pass_quantize_convolutions, pass_propagate_datatypes, pass_propagate_output_type_backward
+    pass_quantize_convolutions, pass_propagate_datatypes, pass_propagate_output_type_backward, \
+    pass_lookup
 
 SCRITPS_DIR = path.abspath(path.dirname(__file__))
 DLK_ROOT_DIR = path.abspath(path.join(SCRITPS_DIR, '..'))
@@ -55,6 +56,7 @@ def optimize_graph_step(model: Model, config: Config) -> None:
     pass_transpose(graph)
 
     if config.activate_hard_quantization:
+        pass_lookup(graph)
         pass_propagate_quantization_details_into_conv(graph)
         if config.threshold_skipping:
             pass_compute_thresholds(graph)

--- a/dlk/python/dlk/templates/Makefile.tpl
+++ b/dlk/python/dlk/templates/Makefile.tpl
@@ -42,7 +42,8 @@ LIB_SRC := $(wildcard $(INPUTS_SRC_DIR)/*.cpp) \
     $(SRC_DIR)/network_c_interface.cpp \
     $(SRC_DIR)/network.cpp \
     $(SRC_DIR)/pack_input_to_qwords.cpp \
-    $(SRC_DIR)/time_measurement.cpp
+    $(SRC_DIR)/time_measurement.cpp \
+    $(SRC_DIR)/write_to_file.cpp
 
 SRC := $(LIB_SRC) $(wildcard $(DLK_TEST_SRC_DIR)/*.cpp) mains/main.cpp
 SRC := $(filter-out ./src/network_c_interface.cpp, $(SRC))
@@ -153,7 +154,7 @@ lm_arm:           FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DUSE_PNG -mcpu
 lm_arm:           CXXFLAGS +=
 
 lm_fpga:          CXX = arm-linux-gnueabihf-g++
-lm_fpga:          FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DRUN_ON_FPGA -DUSE_PNG -mcpu=cortex-a9 -mfpu=neon -mthumb -s -pthread -g -fopenmp
+lm_fpga:          FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DRUN_ON_FPGA -DUSE_PNG -mcpu=cortex-a9 -mfpu=neon -mthumb -pthread -g -fopenmp -DFUNC_TIME_MEASUREMENT
 lm_fpga:          CXXFLAGS +=
 
 lib_x86:           CXX = g++

--- a/dlk/python/dlk/templates/Makefile.tpl
+++ b/dlk/python/dlk/templates/Makefile.tpl
@@ -38,6 +38,7 @@ LIB_SRC := $(wildcard $(INPUTS_SRC_DIR)/*.cpp) \
     $(SRC_DIR)/func/sqrt.cpp \
     $(SRC_DIR)/func/sub.cpp \
     $(SRC_DIR)/func/unpooling.cpp \
+    $(SRC_DIR)/func/lookup.cpp \
     $(SRC_DIR)/matrix/shift_add.cpp \
     $(SRC_DIR)/network_c_interface.cpp \
     $(SRC_DIR)/network.cpp \

--- a/dlk/python/dlk/templates/include/de10_nano.h
+++ b/dlk/python/dlk/templates/include/de10_nano.h
@@ -256,4 +256,338 @@ void qconv_kn2row_tiling(unsigned long input_addr, unsigned long output_addr,
   }
 }
 
+//
+// TCA
+//
+uint8_t* mapPhysicalMemory(size_t base, size_t size) {
+    int fd = open("/dev/mem", O_RDWR | O_SYNC, 0);
+    if (fd == -1)
+        throw std::system_error(errno, std::generic_category());
+    int rw = PROT_READ | PROT_WRITE;
+    auto* mapped_base = reinterpret_cast<uint8_t*>(mmap(nullptr, size, rw, MAP_SHARED, fd, base));
+    if (mapped_base == MAP_FAILED)
+        throw std::system_error(errno, std::generic_category());
+    return mapped_base;
+}
+
+struct Csr {
+    static constexpr uint32_t start = 0;
+    static constexpr uint32_t admaInputAddress = 1;
+    static constexpr uint32_t admaInputHCount = 2;
+    static constexpr uint32_t admaInputWCount = 3;
+    static constexpr uint32_t admaInputCCount = 4;
+    static constexpr uint32_t admaTopTileH = 5;
+    static constexpr uint32_t admaMiddleTileH = 6;
+    static constexpr uint32_t admaBottomTileH = 7;
+    static constexpr uint32_t admaLeftTileW = 8;
+    static constexpr uint32_t admaMiddleTileW = 9;
+    static constexpr uint32_t admaRightTileW = 10;
+    static constexpr uint32_t admaLeftRowToRowDistance = 11;
+    static constexpr uint32_t admaMiddleRowToRowDistance = 12;
+    static constexpr uint32_t admaRightRowToRowDistance = 13;
+    static constexpr uint32_t admaLeftStep = 14;
+    static constexpr uint32_t admaMiddleStep = 15;
+    static constexpr uint32_t admaTopRowDistance = 16;
+    static constexpr uint32_t admaMidRowDistance = 17;
+    static constexpr uint32_t admaInputSpace = 18;
+    static constexpr uint32_t admaTopBottomLeftPad = 19;
+    static constexpr uint32_t admaTopBottomMiddlePad = 20;
+    static constexpr uint32_t admaTopBottomRightPad = 21;
+    static constexpr uint32_t admaSidePad = 22;
+    static constexpr uint32_t wdmaStartAddress = 23;
+    static constexpr uint32_t wdmaOutputHCount = 24;
+    static constexpr uint32_t wdmaOutputWCount = 25;
+    static constexpr uint32_t wdmaKernelBlockCount = 26;
+    static constexpr uint32_t fdmaOutputAddress = 27;
+    static constexpr uint32_t fdmaOutputHCount = 28;
+    static constexpr uint32_t fdmaOutputWCount = 29;
+    static constexpr uint32_t fdmaOutputCCount = 30;
+    static constexpr uint32_t fdmaRegularTileH = 31;
+    static constexpr uint32_t fdmaLastTileH = 32;
+    static constexpr uint32_t fdmaRegularTileW = 33;
+    static constexpr uint32_t fdmaLastTileW = 34;
+    static constexpr uint32_t fdmaRegularRowToRowDistance = 35;
+    static constexpr uint32_t fdmaLastRowToRowDistance = 36;
+    static constexpr uint32_t fdmaOutputSpace = 37;
+    static constexpr uint32_t fdmaRowDistance = 38;
+    static constexpr uint32_t a2fInputCCount = 39;
+    static constexpr uint32_t a2fKernelVCount = 40;
+    static constexpr uint32_t a2fKernelHCount = 41;
+    static constexpr uint32_t a2fTileStep = 42;
+    static constexpr uint32_t a2fTileGap = 43;
+    static constexpr uint32_t a2fOutputHCount = 44;
+    static constexpr uint32_t a2fOutputWCount = 45;
+    static constexpr uint32_t a2fRegularTileH = 46;
+    static constexpr uint32_t a2fLastTileH = 47;
+    static constexpr uint32_t a2fRegularTileW = 48;
+    static constexpr uint32_t a2fLastTileW = 49;
+    static constexpr uint32_t qdmaStartAddress = 50;
+    static constexpr uint32_t bnqEnable = 51;
+
+    static constexpr uint32_t statusRegister = 52;
+};
+
+struct Parameters {
+    uint32_t admaInputAddress;
+    uint32_t admaInputHCount;
+    uint32_t admaInputWCount;
+    uint32_t admaInputCCount;
+    uint32_t admaTopTileH;
+    uint32_t admaMiddleTileH;
+    uint32_t admaBottomTileH;
+    uint32_t admaLeftTileW;
+    uint32_t admaMiddleTileW;
+    uint32_t admaRightTileW;
+    uint32_t admaLeftRowToRowDistance;
+    uint32_t admaMiddleRowToRowDistance;
+    uint32_t admaRightRowToRowDistance;
+    uint32_t admaLeftStep;
+    uint32_t admaMiddleStep;
+    uint32_t admaTopRowDistance;
+    uint32_t admaMidRowDistance;
+    uint32_t admaInputSpace;
+    uint32_t admaTopBottomLeftPad;
+    uint32_t admaTopBottomMiddlePad;
+    uint32_t admaTopBottomRightPad;
+    uint32_t admaSidePad;
+    uint32_t wdmaStartAddress;
+    uint32_t wdmaOutputHCount;
+    uint32_t wdmaOutputWCount;
+    uint32_t wdmaKernelBlockCount;
+    uint32_t fdmaOutputAddress;
+    uint32_t fdmaOutputHCount;
+    uint32_t fdmaOutputWCount;
+    uint32_t fdmaOutputCCount;
+    uint32_t fdmaRegularTileH;
+    uint32_t fdmaLastTileH;
+    uint32_t fdmaRegularTileW;
+    uint32_t fdmaLastTileW;
+    uint32_t fdmaRegularRowToRowDistance;
+    uint32_t fdmaLastRowToRowDistance;
+    uint32_t fdmaOutputSpace;
+    uint32_t fdmaRowDistance;
+    uint32_t a2fInputCCount;
+    uint32_t a2fKernelVCount;
+    uint32_t a2fKernelHCount;
+    uint32_t a2fTileStep;
+    uint32_t a2fTileGap;
+    uint32_t a2fOutputHCount;
+    uint32_t a2fOutputWCount;
+    uint32_t a2fRegularTileH;
+    uint32_t a2fLastTileH;
+    uint32_t a2fRegularTileW;
+    uint32_t a2fLastTileW;
+    uint32_t qdmaStartAddress;
+    uint32_t bnqEnable;
+};
+
+Parameters calcParameters(uint32_t inputHeight, uint32_t inputWidth, uint32_t inputChannels, uint32_t inputTileWidth, uint32_t inputTileHeight,
+    uint32_t outputChannels, uint32_t kernelHeight, uint32_t kernelWidth, uint32_t inputAddress, uint32_t kernelAddress, uint32_t thresholdAddress, uint32_t outputAddress, bool enable_bnq) {
+
+  auto divRoundUp = [](uint32_t x, uint32_t y) {
+    return (x + y - 1) / y;
+  };
+
+  constexpr uint32_t maxBurst = 32;
+  constexpr uint32_t b = 32;
+
+  assert((kernelHeight == 3 && kernelWidth == 3) || (kernelHeight == 1 && kernelWidth == 1));
+
+  uint32_t pad = (kernelHeight == 1) ? 0 : 1;
+  uint32_t dep = kernelHeight - 1;
+
+  auto outputHeight = inputHeight + 2 * pad - dep;
+  auto outputWidth = inputWidth + 2 * pad - dep;
+
+  auto outputTileHeight = inputTileHeight - dep;
+  auto outputTileWidth = inputTileWidth - dep;
+
+  assert(inputTileHeight > dep && inputTileWidth > dep);
+
+  auto hCount = divRoundUp(outputHeight, outputTileHeight);
+  auto wCount = divRoundUp(outputWidth, outputTileWidth);
+
+  // ADMA Parameters
+  Parameters p;
+  p.admaInputAddress = inputAddress;
+  p.admaInputHCount = hCount;
+  p.admaInputWCount = wCount;
+
+  p.admaInputCCount = divRoundUp(inputChannels, b);
+
+  p.admaTopTileH = (hCount == 1) ? inputHeight : (inputTileHeight - pad);
+  p.admaMiddleTileH = inputTileHeight;
+  p.admaBottomTileH = inputHeight + pad - (hCount - 1)  * (inputTileHeight - dep);
+
+  p.admaLeftTileW = (wCount == 1) ? inputWidth : (inputTileWidth - pad);
+  p.admaMiddleTileW = inputTileWidth;
+  p.admaRightTileW = (wCount == 1) ? inputWidth : inputWidth + pad - (wCount - 1) * (inputTileWidth - dep);
+
+  p.admaLeftRowToRowDistance = inputWidth - p.admaLeftTileW + ((p.admaLeftTileW % maxBurst == 0) ? maxBurst : p.admaLeftTileW % maxBurst);
+  p.admaMiddleRowToRowDistance = inputWidth - p.admaMiddleTileW + ((p.admaMiddleTileW % maxBurst == 0) ? maxBurst : p.admaMiddleTileW % maxBurst);
+  p.admaRightRowToRowDistance = inputWidth - p.admaRightTileW + ((p.admaRightTileW % maxBurst == 0) ? maxBurst : p.admaRightTileW % maxBurst);
+
+  p.admaLeftStep = p.admaLeftTileW - dep;
+  p.admaMiddleStep = p.admaMiddleTileW - dep;
+
+  p.admaTopRowDistance = inputWidth * (p.admaTopTileH - dep) - inputWidth + p.admaRightTileW;
+  p.admaMidRowDistance = inputWidth * (p.admaMiddleTileH - dep) - inputWidth + p.admaRightTileW;
+
+  p.admaInputSpace = inputHeight * inputWidth;
+
+  p.admaTopBottomLeftPad = (p.admaLeftTileW + pad) * pad;
+  p.admaTopBottomMiddlePad = p.admaMiddleTileW * pad;
+  p.admaTopBottomRightPad = (p.admaRightTileW + pad) * pad;
+  p.admaSidePad = (wCount == 1) ? (2 * pad) : pad;
+
+  // WDMA Parameters
+  p.wdmaStartAddress = kernelAddress;
+  p.wdmaOutputHCount = hCount;
+  p.wdmaOutputWCount = wCount;
+  p.wdmaKernelBlockCount = divRoundUp(outputChannels, b) * divRoundUp(inputChannels, b) * kernelHeight * kernelWidth;
+
+  // FDMA Parameters
+  //bool enableBnq = true;
+  const uint32_t dataWidth = (enable_bnq) ? b * 2 : b * 16;
+  const uint32_t avalonDataWidth = (enable_bnq) ? b * 2 : 128;
+  auto bytesPerElement = dataWidth / 8;
+  auto wordsPerElement = dataWidth / avalonDataWidth;
+
+  auto fdmaRowToRowDistance = [&](uint32_t outputWidth, uint32_t tileWidth) {
+    return (outputWidth - tileWidth) * wordsPerElement + 1;
+  };
+
+  p.fdmaOutputAddress = outputAddress;
+
+  p.fdmaOutputHCount = hCount;
+  p.fdmaOutputWCount = wCount;
+  p.fdmaOutputCCount = divRoundUp(outputChannels, b);
+
+  p.fdmaRegularTileH = outputTileHeight;
+  p.fdmaLastTileH = outputHeight - (hCount - 1)  * outputTileHeight;
+
+  p.fdmaRegularTileW = outputTileWidth;
+  p.fdmaLastTileW = outputWidth - (wCount - 1)  * outputTileWidth;
+
+  p.fdmaRegularRowToRowDistance = fdmaRowToRowDistance(outputWidth, p.fdmaRegularTileW);
+  p.fdmaLastRowToRowDistance = fdmaRowToRowDistance(outputWidth, p.fdmaLastTileW);
+
+  p.fdmaOutputSpace = outputHeight * outputWidth;
+  p.fdmaRowDistance = outputWidth * p.fdmaRegularTileH - outputWidth + p.fdmaLastTileW;
+
+  // A2F Parameters
+  p.a2fInputCCount = p.admaInputCCount;
+  p.a2fKernelVCount = kernelHeight;
+  p.a2fKernelHCount = kernelWidth;
+
+  if (kernelHeight == 1) {
+    p.a2fTileStep = 1u;
+    p.a2fTileGap = 1u;
+  }
+  else {
+    // TODO: 3x3 stride one assumed here
+    p.a2fTileStep = 1u;
+    p.a2fTileGap = 3u;
+  }
+
+  p.a2fOutputHCount = hCount;
+  p.a2fOutputWCount = wCount;
+
+  p.a2fRegularTileH = outputTileHeight;
+  p.a2fLastTileH = outputHeight - (hCount - 1) * p.a2fRegularTileH;
+  p.a2fRegularTileW = outputTileWidth;
+  p.a2fLastTileW = outputWidth - (wCount - 1) * p.a2fRegularTileW;
+
+  p.qdmaStartAddress = thresholdAddress;
+  p.bnqEnable = enable_bnq ? 1 : 0;
+
+  return p;
+}
+
+void RunTCA(unsigned long input_addr, unsigned long output_addr, unsigned long kernel_addr,
+  BIN_CONV_OUTPUT th_data[], unsigned in_w, unsigned in_h, unsigned in_c, unsigned nbits_in_data,
+  unsigned out_w, unsigned out_h, unsigned out_c, unsigned k_w, unsigned k_h, unsigned pad, unsigned stride) {
+
+  const unsigned k_size = (k_h * k_w * in_c * out_c) / 32;
+  // MappedMem k_data_mem(KERNEL_ADDR, k_size, sizeof(T_UINT));
+  // k_data_mem.Write(k_data_packed, k_size);
+
+  unsigned use_threshold = (th_data != NULL) ? 1 : 0;
+
+  if (use_threshold == 1) {
+    const unsigned th_size = out_c * NUM_OF_A2W1_THRESHOLD;
+    MappedMem th_data_mem(THRESHOLD_ADDR, th_size, sizeof(BIN_CONV_OUTPUT));
+    th_data_mem.Write(th_data, th_size);
+  }
+
+  static volatile uint32_t* csr = nullptr;
+  if (csr == nullptr) {
+    csr = reinterpret_cast<uint32_t*>(mapPhysicalMemory(HPS_TO_FPGA_LW_BASE, 0xFF));
+  }
+    auto tileWidth = 32u;
+    auto tileHeight = 32u;
+    auto p = calcParameters(in_h, in_w, in_c, tileWidth, tileHeight, out_c, k_h, k_w, input_addr, kernel_addr, THRESHOLD_ADDR, output_addr, use_threshold == 1);
+
+    csr[Csr::admaInputAddress] = p.admaInputAddress;
+    csr[Csr::admaInputHCount] = p.admaInputHCount;
+    csr[Csr::admaInputWCount] = p.admaInputWCount;
+    csr[Csr::admaInputCCount] = p.admaInputCCount;
+    csr[Csr::admaTopTileH] = p.admaTopTileH;
+    csr[Csr::admaMiddleTileH] = p.admaMiddleTileH;
+    csr[Csr::admaBottomTileH] = p.admaBottomTileH;
+    csr[Csr::admaLeftTileW] = p.admaLeftTileW;
+    csr[Csr::admaMiddleTileW] = p.admaMiddleTileW;
+    csr[Csr::admaRightTileW] = p.admaRightTileW;
+    csr[Csr::admaLeftRowToRowDistance] = p.admaLeftRowToRowDistance;
+    csr[Csr::admaMiddleRowToRowDistance] = p.admaMiddleRowToRowDistance;
+    csr[Csr::admaRightRowToRowDistance] = p.admaRightRowToRowDistance;
+    csr[Csr::admaLeftStep] = p.admaLeftStep;
+    csr[Csr::admaMiddleStep] = p.admaMiddleStep;
+    csr[Csr::admaTopRowDistance] = p.admaTopRowDistance;
+    csr[Csr::admaMidRowDistance] = p.admaMidRowDistance;
+    csr[Csr::admaInputSpace] = p.admaInputSpace;
+    csr[Csr::admaTopBottomLeftPad] = p.admaTopBottomLeftPad;
+    csr[Csr::admaTopBottomMiddlePad] = p.admaTopBottomMiddlePad;
+    csr[Csr::admaTopBottomRightPad] = p.admaTopBottomRightPad;
+    csr[Csr::admaSidePad] = p.admaSidePad;
+    csr[Csr::wdmaStartAddress] = p.wdmaStartAddress;
+    csr[Csr::wdmaOutputHCount] = p.wdmaOutputHCount;
+    csr[Csr::wdmaOutputWCount] = p.wdmaOutputWCount;
+    csr[Csr::wdmaKernelBlockCount] = p.wdmaKernelBlockCount;
+    csr[Csr::fdmaOutputAddress] = p.fdmaOutputAddress;
+    csr[Csr::fdmaOutputHCount] = p.fdmaOutputHCount;
+    csr[Csr::fdmaOutputWCount] = p.fdmaOutputWCount;
+    csr[Csr::fdmaOutputCCount] = p.fdmaOutputCCount;
+    csr[Csr::fdmaRegularTileH] = p.fdmaRegularTileH;
+    csr[Csr::fdmaLastTileH] = p.fdmaLastTileH;
+    csr[Csr::fdmaRegularTileW] = p.fdmaRegularTileW;
+    csr[Csr::fdmaLastTileW] = p.fdmaLastTileW;
+    csr[Csr::fdmaRegularRowToRowDistance] = p.fdmaRegularRowToRowDistance;
+    csr[Csr::fdmaLastRowToRowDistance] = p.fdmaLastRowToRowDistance;
+    csr[Csr::fdmaOutputSpace] = p.fdmaOutputSpace;
+    csr[Csr::fdmaRowDistance] = p.fdmaRowDistance;
+    csr[Csr::a2fInputCCount] = p.a2fInputCCount;
+    csr[Csr::a2fKernelVCount] = p.a2fKernelVCount;
+    csr[Csr::a2fKernelHCount] = p.a2fKernelHCount;
+    csr[Csr::a2fTileStep] = p.a2fTileStep;
+    csr[Csr::a2fTileGap] = p.a2fTileGap;
+    csr[Csr::a2fOutputHCount] = p.a2fOutputHCount;
+    csr[Csr::a2fOutputWCount] = p.a2fOutputWCount;
+    csr[Csr::a2fRegularTileH] = p.a2fRegularTileH;
+    csr[Csr::a2fLastTileH] = p.a2fLastTileH;
+    csr[Csr::a2fRegularTileW] = p.a2fRegularTileW;
+    csr[Csr::a2fLastTileW] = p.a2fLastTileW;
+    csr[Csr::qdmaStartAddress] = p.qdmaStartAddress;
+    csr[Csr::bnqEnable] = p.bnqEnable;
+
+    // std::cout << "Status " << csr[Csr::statusRegister] << std::endl;
+    csr[Csr::start] = 1;
+
+    // std::cout << "Status " << csr[Csr::statusRegister] << std::endl;
+    while (csr[Csr::statusRegister] != 127) {
+        // std::cout << "Status " << csr[Csr::statusRegister] << std::endl;
+        continue;
+    }
+}
+
 } // namespace de10_nano

--- a/dlk/python/dlk/templates/include/func/concat_on_depth.h
+++ b/dlk/python/dlk/templates/include/func/concat_on_depth.h
@@ -27,6 +27,10 @@ void func_ConcatOnDepth(T *inputs[], T_UINT *depths, T_UINT n_inputs, T output[]
   T_UINT output_index = 0;
   T_UINT input_index[32] = {0};
 
+  // expects quantized and packed inputs
+  for(T_UINT i = 0; i < n_inputs; i++)
+    depths[i] /= 16;
+
   for(T_UINT i = 0; i < out_height * out_width; i++)
     for(T_UINT n = 0; n < n_inputs; n++)
       for(T_UINT d = 0; d < depths[n]; d++)

--- a/dlk/python/dlk/templates/include/func/extract_image_patches.h
+++ b/dlk/python/dlk/templates/include/func/extract_image_patches.h
@@ -34,9 +34,9 @@ void func_ExtractImagePatches(QUANTIZED_PACKED input[], QUANTIZED_PACKED output[
   T_UINT packed_input_depth = full_words_in_depth * bits_per_input + (remainder_bits_in_depth ? bits_per_input : 0);
   T_UINT packed_output_size = packed_input_depth * kernel_size * kernel_size * out_width * out_height;
 
-  QUANTIZED_PACKED* output_buffer = new QUANTIZED_PACKED[packed_output_size];
+  auto output_buffer = std::make_unique<QUANTIZED_PACKED[]>(packed_output_size);
 
-  auto* out = (input_depth < 32) ? output_buffer : output;
+  auto* out = (input_depth < 32) ? output_buffer.get() : output;
   T_UINT output_index = 0;
   for(T_UINT wi = 0; wi < out_height; wi++)
     for(T_UINT wj = 0; wj < out_width; wj++)
@@ -72,7 +72,6 @@ void func_ExtractImagePatches(QUANTIZED_PACKED input[], QUANTIZED_PACKED output[
     }
   }
 
-  delete [] output_buffer;
   Measurement::Stop();
 }
 

--- a/dlk/python/dlk/templates/include/func/extract_image_patches.h
+++ b/dlk/python/dlk/templates/include/func/extract_image_patches.h
@@ -18,28 +18,61 @@ limitations under the License.
 
 #include "global.h"
 #include "time_measurement.h"
+#include "pack_input_to_qwords.h"
+#include <limits.h>
 
-template<class T>
-void func_ExtractImagePatches(T input[], T output[], T_UINT input_width, T_UINT input_depth, T_UINT kernel_size, T_UINT stride, T_UINT out_height, T_UINT out_width, T_UINT out_depth)
+
+void func_ExtractImagePatches(QUANTIZED_PACKED input[], QUANTIZED_PACKED output[], T_UINT input_width, T_UINT input_depth, T_UINT kernel_size, T_UINT stride, T_UINT out_height, T_UINT out_width, T_UINT out_depth)
 {
   Measurement::Start("ExtractImagePatches");
 
-  T_UINT output_index = 0;
+  const int bits_per_input = 2;
+  const int bits_per_word = sizeof(QUANTIZED_PACKED) * CHAR_BIT;
+  int full_words_in_depth = input_depth / bits_per_word;
+  int remainder_bits_in_depth = input_depth % bits_per_word;
 
+  T_UINT packed_input_depth = full_words_in_depth * bits_per_input + (remainder_bits_in_depth ? bits_per_input : 0);
+  T_UINT packed_output_size = packed_input_depth * kernel_size * kernel_size * out_width * out_height;
+
+  QUANTIZED_PACKED* output_buffer = new QUANTIZED_PACKED[packed_output_size];
+
+  auto* out = (input_depth < 32) ? output_buffer : output;
+  T_UINT output_index = 0;
   for(T_UINT wi = 0; wi < out_height; wi++)
     for(T_UINT wj = 0; wj < out_width; wj++)
     {
       for(T_UINT ki = 0; ki < kernel_size; ki++)
         for(T_UINT kj = 0; kj < kernel_size; kj++)
-          for(T_UINT kz = 0; kz < input_depth; kz++)
+          for(T_UINT kz = 0; kz < packed_input_depth; kz++)
           {
             T_INT row = (wi * stride) + ki;
             T_INT col = (wj * stride) + kj;
 
-            output[output_index++] = input[row * (input_width * input_depth) + col * (input_depth) + kz];
+            out[output_index++] = input[row * (input_width * packed_input_depth) + col * (packed_input_depth) + kz];
           }
-      }
+    }
 
+  if(input_depth < 32) {
+    T_UINT chunk_size = input_depth;
+    T_UINT chunks_per_word = 32 / chunk_size;
+    T_UINT chunk_mask = (1 << chunk_size) - 1;
+
+    for(int offset = 0;  offset < bits_per_input; offset++) {
+        T_UINT current_input_word = offset;
+        T_UINT current_output_word = offset;
+
+        for(int output_blocks = 0;  output_blocks < (packed_output_size / bits_per_input); output_blocks += chunks_per_word) {
+          output[current_output_word] = QUANTIZED_PACKED(0);
+          for(int chunk = 0; chunk < chunks_per_word; chunk++) {
+            output[current_output_word] = QUANTIZED_PACKED(output[current_output_word].Raw() | (output_buffer[current_input_word].Raw() & chunk_mask) << (chunk * chunk_size));
+            current_input_word += bits_per_input;
+          }
+          current_output_word += bits_per_input;
+        }
+    }
+  }
+
+  delete [] output_buffer;
   Measurement::Stop();
 }
 

--- a/dlk/python/dlk/templates/include/func/impl/quantized_conv2d_kn2row.h
+++ b/dlk/python/dlk/templates/include/func/impl/quantized_conv2d_kn2row.h
@@ -23,9 +23,11 @@ namespace dlk {
 
 namespace impl {
 
-void QuantizedConv2DKn2Row(QUANTIZED_NOT_PACKED input[],
+void QuantizedConv2DKn2Row(QUANTIZED_PACKED input[],
                                   const QUANTIZED_PACKED_KERNEL kernel[],
                                   const binary_convolution_parameters &p);
+
+void TCAConv2d(QUANTIZED_PACKED input[], const QUANTIZED_PACKED_KERNEL kernel[], const binary_convolution_parameters &p);
 
 } // namespace impl
 

--- a/dlk/python/dlk/templates/include/func/lookup.h
+++ b/dlk/python/dlk/templates/include/func/lookup.h
@@ -1,0 +1,23 @@
+/* Copyright 2018 The Blueoil Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef DLK_FUNC_LOOKUP_H_INCLUDED
+#define DLK_FUNC_LOOKUP_H_INCLUDED
+
+#include "global.h"
+
+void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c);
+
+#endif // DLK_FUNC_LOOKUP_H_INCLUDED

--- a/dlk/python/dlk/templates/include/func/quantized_conv2d.h
+++ b/dlk/python/dlk/templates/include/func/quantized_conv2d.h
@@ -22,7 +22,7 @@ limitations under the License.
 
 
 void func_QuantizedConv2D(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
   T_FLOAT output[],
   T_FLOAT scaling_factor,
@@ -30,7 +30,7 @@ void func_QuantizedConv2D(
 );
 
 void func_QuantizedConv2D(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
   T_FLOAT output[],
   T_FLOAT scaling_factor[],
@@ -38,23 +38,23 @@ void func_QuantizedConv2D(
 );
 
 void func_QuantizedConv2DWithThreshold(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
-  QUANTIZED_NOT_PACKED output[],
+  QUANTIZED_PACKED output[],
   T_FLOAT scaling_factor,
   binary_convolution_parameters p
 );
 
 void func_QuantizedConv2DWithThreshold(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
-  QUANTIZED_NOT_PACKED output[],
+  QUANTIZED_PACKED output[],
   T_FLOAT scaling_factor[],
   binary_convolution_parameters p
 );
 
 void func_QuantizedConv2DWithThreshold(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
   T_FLOAT output[],
   T_FLOAT scaling_factor,
@@ -62,7 +62,7 @@ void func_QuantizedConv2DWithThreshold(
 );
 
 void func_QuantizedConv2DWithThreshold(
-  QUANTIZED_NOT_PACKED input[],
+  QUANTIZED_PACKED input[],
   QUANTIZED_PACKED_KERNEL kernel[],
   T_FLOAT output[],
   T_FLOAT scaling_factor[],

--- a/dlk/python/dlk/templates/include/global.tpl.h
+++ b/dlk/python/dlk/templates/include/global.tpl.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <climits>
 #include <inttypes.h>
 #include <limits>
+#include <stdlib.h>
 #include <type_traits>
 #include "func/impl/pop_count.h"
 
@@ -142,6 +143,21 @@ struct Base<QuantizedPacked<T>> {
 /********************************************************/
 
 typedef T_INT Quantized_t;
+
+void write_to_file(const char *filename, int id, volatile int32_t* data, int size);
+void write_to_file(const char *filename, int id, volatile BIN_CONV_OUTPUT* data, int size);
+void write_to_file(const char *filename, int id, QUANTIZED_NOT_PACKED* data, int size);
+void write_to_file(const char *filename, int id, float* data, int size);
+
+// TCA
+
+// HPS-TO-FPGA Lightweight bridge address
+constexpr size_t HPS_TO_FPGA_LW_BASE = 0xFF200000;
+
+// Half part of phys memory
+constexpr size_t HW_BUFFERS_PHYS_ADDR_BASE = 0x20000000;
+
+void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c);
 
 
 #endif

--- a/dlk/python/dlk/templates/include/global.tpl.h
+++ b/dlk/python/dlk/templates/include/global.tpl.h
@@ -157,8 +157,5 @@ constexpr size_t HPS_TO_FPGA_LW_BASE = 0xFF200000;
 // Half part of phys memory
 constexpr size_t HW_BUFFERS_PHYS_ADDR_BASE = 0x20000000;
 
-void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c);
-
-
 #endif
 

--- a/dlk/python/dlk/templates/include/matrix/multiplication.h
+++ b/dlk/python/dlk/templates/include/matrix/multiplication.h
@@ -52,6 +52,9 @@ inline void matrix_multiplication_col3(
       vst1q_f32(C.data(j, i), r);
     }
   }
+  // FIXME: hacky way to prevent memory leak
+  delete [] A_colm.data();
+
 #endif
 }
 

--- a/dlk/python/dlk/templates/include/operators.h
+++ b/dlk/python/dlk/templates/include/operators.h
@@ -56,9 +56,11 @@ struct binary_convolution_parameters {
   T_FLOAT max_value;
   unsigned long device_input_phys_addr;
   unsigned long device_output_phys_addr;
+  unsigned long device_kernel_phys_addr;
 
   DMA_Buffer *dma_input_buffer;
   DMA_Buffer *dma_output_buffer;
+  const char* debug_name;
 };
 
 #endif

--- a/dlk/python/dlk/templates/include/pack_input_to_qwords.h
+++ b/dlk/python/dlk/templates/include/pack_input_to_qwords.h
@@ -29,4 +29,8 @@ void pack_input_to_qwords(
   QUANTIZED_PACKED output[],
   struct binary_convolution_parameters bcp);
 
+
+int pack_input(QUANTIZED_NOT_PACKED input[], size_t input_height, size_t input_width, size_t input_depth,
+  size_t bits_per_input, QUANTIZED_PACKED output[]);
+
 #endif // DLK_PACK_INPUT_TO_QWORDS_H_INCLUDED

--- a/dlk/python/dlk/templates/include/time_measurement.h
+++ b/dlk/python/dlk/templates/include/time_measurement.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <vector>
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <unordered_map>
 
 #define TIME_ORDER std::chrono::microseconds
 
@@ -35,8 +37,24 @@ private:
     std::chrono::system_clock::time_point end;
   };
 
+  struct Node {
+    Node(const std::string& name, size_t position)
+        : name(name), position(position) {
+    }
+
+    std::string name;
+    size_t position;
+    std::vector<measure> measurements;
+    std::unordered_map<std::string, std::unique_ptr<Node>> children;
+  };
+
   static std::map<std::string, std::vector<Measurement::measure> > times;
   static std::vector<std::string> current_context;
+
+  static std::vector<Node*> stack;
+  static std::vector<std::unique_ptr<Node>> roots;
+
+  static void DumpTimeTree(const Node&, int level);
 
 public:
   static void Start(const std::string &measure_name);

--- a/dlk/python/dlk/templates/src/func/impl/quantized_conv2d_dim2col.cpp
+++ b/dlk/python/dlk/templates/src/func/impl/quantized_conv2d_dim2col.cpp
@@ -201,9 +201,8 @@ void QuantizedConv2DIm2Col(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL
   int kw = p.normal_conv_params.kernel_width;
 
   unsigned im2col_input_elems = oh * ow * kh * kw * ic;
-  // pack_input_to_qwords(im2col_input_buf, p.device_input_buf, p);
-  pack_input_to_qwords(im2col_input_buf, p.device_input_buf, im2col_input_elems,
-                       2);
+  pack_input_to_qwords(im2col_input_buf, p.device_input_buf, p);
+  //pack_input_to_qwords(im2col_input_buf, p.device_input_buf, im2col_input_elems,2);
   Measurement::Stop();
 
   Measurement::Start("QConv2D with im2col");

--- a/dlk/python/dlk/templates/src/func/lookup.cpp
+++ b/dlk/python/dlk/templates/src/func/lookup.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2018 The Blueoil Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "global.h"
+#include "func/lookup.h"
+#include "time_measurement.h"
+
+void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c) {
+
+  int b = 32;
+  int packed_depth = 2;
+  Measurement::Start("Lookup");
+
+  int out_idx = 0;
+  for(int ih = 0; ih < h; ih++)
+  for(int iw = 0; iw < w; iw++) {
+    int r = int(input[ih * w * 3 + iw * 3 + 0] * 255.0);
+    int g = int(input[ih * w * 3 + iw * 3 + 1] * 255.0);
+    int b = int(input[ih * w * 3 + iw * 3 + 2] * 255.0);
+
+    auto r_lsb = lsb[r];
+    auto g_lsb = lsb[g];
+    auto b_lsb = lsb[b];
+    auto r_msb = msb[r];
+    auto g_msb = msb[g];
+    auto b_msb = msb[b];
+
+    output[out_idx++] = QUANTIZED_PACKED((b_lsb.Raw() << 20) | (g_lsb.Raw() << 10) | r_lsb.Raw());
+    output[out_idx++] = QUANTIZED_PACKED((b_msb.Raw() << 20) | (g_msb.Raw() << 10) | r_msb.Raw());
+  }
+
+  Measurement::Stop();
+}
+

--- a/dlk/python/dlk/templates/src/func/quantized_conv2d.cpp
+++ b/dlk/python/dlk/templates/src/func/quantized_conv2d.cpp
@@ -303,30 +303,3 @@ void func_QuantizedConv2DWithThreshold(QUANTIZED_PACKED input[],
                                     p);
 }
 
-
-void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c) {
-
-  int b = 32;
-  int packed_depth = 2;
-  Measurement::Start("Lookup");
-
-  int out_idx = 0;
-  for(int ih = 0; ih < h; ih++)
-  for(int iw = 0; iw < w; iw++) {
-    int r = int(input[ih * w * 3 + iw * 3 + 0] * 255.0);
-    int g = int(input[ih * w * 3 + iw * 3 + 1] * 255.0);
-    int b = int(input[ih * w * 3 + iw * 3 + 2] * 255.0);
-
-    auto r_lsb = lsb[r];
-    auto g_lsb = lsb[g];
-    auto b_lsb = lsb[b];
-    auto r_msb = msb[r];
-    auto g_msb = msb[g];
-    auto b_msb = msb[b];
-
-    output[out_idx++] = QUANTIZED_PACKED((b_lsb.Raw() << 20) | (g_lsb.Raw() << 10) | r_lsb.Raw());
-    output[out_idx++] = QUANTIZED_PACKED((b_msb.Raw() << 20) | (g_msb.Raw() << 10) | r_msb.Raw());
-  }
-
-  Measurement::Stop();
-}

--- a/dlk/python/dlk/templates/src/func/quantized_conv2d.cpp
+++ b/dlk/python/dlk/templates/src/func/quantized_conv2d.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "func/impl/quantized_conv2d_kn2row.h"
 #include "func/quantized_conv2d.h"
 #include "time_measurement.h"
+#include "pack_input_to_qwords.h"
 
 namespace {
 
@@ -46,7 +47,7 @@ void func_linear_to_float(BIN_CONV_OUTPUT input[], T_INT nbit,
   }
 }
 
-void QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
+void QuantizedConv2D(QUANTIZED_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
                             binary_convolution_parameters p) {
   constexpr T_UINT TilingInTypeBitWidth = CHAR_BIT * sizeof(QUANTIZED_PACKED);
   int kh = p.normal_conv_params.kernel_height;
@@ -59,8 +60,8 @@ void QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL kerne
   auto size = oc * ih * iw;
   if (p.device_output_buf == nullptr)
     p.device_output_buf = new BIN_CONV_OUTPUT[size]();
-  else
-    std::memset((void *)p.device_output_buf, 0, size * sizeof(BIN_CONV_OUTPUT));
+  // else
+  //   std::memset((void *)p.device_output_buf, 0, size * sizeof(BIN_CONV_OUTPUT));
 
   if ((kh == 3 && kw == 3 && padding == 1) ||
       (kh == 1 && kw == 1 && padding == 0)) {
@@ -68,21 +69,28 @@ void QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL kerne
 #if defined(USE_NEON) && !defined(RUN_ON_FPGA)
       dlk::impl::QuantizedConv2DTiling(input, kernel, p);
 #else
-      dlk::impl::QuantizedConv2DKn2Row(input, kernel, p);
+      dlk::impl::TCAConv2d(input, kernel, p);
 #endif
     } else {
-      dlk::impl::QuantizedConv2DKn2Row(input, kernel, p);
+      dlk::impl::TCAConv2d(input, kernel, p);
     }
   } else {
-    dlk::impl::QuantizedConv2DIm2Col(input, kernel, p);
+    ;//dlk::impl::QuantizedConv2DIm2Col(input, kernel, p);
   }
 }
 
 } // namespace
 
-void func_QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
+void func_QuantizedConv2D(QUANTIZED_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
                           T_FLOAT output[], T_FLOAT scaling_factor,
                           binary_convolution_parameters p) {
+
+  unsigned in_elems_wh = p.normal_conv_params.input_height * p.normal_conv_params.input_width;
+  unsigned in_elems = (p.normal_conv_params.kernel_depth > 32 ? (in_elems_wh * p.normal_conv_params.kernel_depth) / 16 : in_elems_wh * 2);
+  static T_UINT in_counter = 0;
+  // write_to_file("out/qconv_input_quantized_packed_ol1_", in_counter++, input, in_elems);
+
+  Measurement::Start("func_QuantizedConv2D");
   Measurement::Start("QuantizedConv2D");
 
   QuantizedConv2D(input, kernel, p);
@@ -95,63 +103,174 @@ void func_QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL 
                        p.normal_conv_params.output_width *
                        p.normal_conv_params.output_channels;
 
+  static T_UINT out_counter = 0;
+  // write_to_file("out/qconv_output_16bit_ol1_", out_counter++, p.device_output_buf, out_elems);
+
+
   // temporary: (2^n - 1) * (max - min)
   const T_FLOAT post_qtz_factor = 2.0f / 3.0f;
+  int b = 32;
+  auto& ncp(p.normal_conv_params);
 
-  for (unsigned i = 0; i < out_elems; ++i) {
-    output[i] = (scaling_factor * post_qtz_factor) * p.device_output_buf[i];
+  if(ncp.output_channels > b) {
+      int out_index = 0;
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int s = 0; s < ncp.output_channels / b; s++)
+      for (int d = 0; d < b; d++)
+        output[out_index++] = (scaling_factor * post_qtz_factor) * p.device_output_buf[h * (ncp.output_channels * ncp.input_width) + w * ncp.output_channels + s * (ncp.input_height * ncp.input_width * b) + d];
+  }
+  else {
+      int tca_channels = ((ncp.output_channels + b - 1) / b) * b;
+      int out_index = 0;
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int d = 0; d < ncp.output_channels; d++)
+        output[out_index++] = (scaling_factor * post_qtz_factor) * p.device_output_buf[h * (tca_channels * ncp.input_width) + w * tca_channels + d];
   }
 
   Measurement::Stop();
+  Measurement::Stop();
 }
 
-void func_QuantizedConv2D(QUANTIZED_NOT_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
+void func_QuantizedConv2D(QUANTIZED_PACKED input[], QUANTIZED_PACKED_KERNEL kernel[],
                           T_FLOAT output[], T_FLOAT scaling_factor[],
                           binary_convolution_parameters p) {
+  Measurement::Start("func_QuantizedConv2D");
   Measurement::Start("QuantizedConv2D");
+
+  unsigned in_elems_wh = p.normal_conv_params.input_height * p.normal_conv_params.input_width;
+  unsigned in_elems = (p.normal_conv_params.kernel_depth > 32 ? (in_elems_wh * p.normal_conv_params.kernel_depth) / 16 : in_elems_wh * 2);
+  static T_UINT in_counter = 0;
+  // write_to_file("out/qconv_input_quantized_packed_ol2_", in_counter++, input, in_elems);
+
 
   QuantizedConv2D(input, kernel, p);
 
   Measurement::Stop();
 
-  Measurement::Start("QuantizedConv2D_ApplyScalingFactor");
 
-  unsigned out_elems =
-      p.normal_conv_params.output_height * p.normal_conv_params.output_width;
+  unsigned out_elems = p.normal_conv_params.output_height * p.normal_conv_params.output_width;
   unsigned out_channels = p.normal_conv_params.output_channels;
+
+  int b = 32;
+  auto& ncp(p.normal_conv_params);
+  int tca_channels = ((ncp.output_channels + b - 1) / b) * b;
+
+  static T_UINT out_counter = 0;
+  // write_to_file("out/qconv_output_16bit_ol2_", out_counter++, p.device_output_buf, out_elems * tca_channels);
 
   // temporary: (2^n - 1) * (max - min)
   T_FLOAT post_qtz_factor = 2.0 / 3.0;
 
-  for (unsigned i = 0; i < out_elems; ++i) {
-    for (unsigned c = 0; c < out_channels; c++) {
-      unsigned idx = i * out_channels + c;
-      BIN_CONV_OUTPUT out = p.device_output_buf[idx];
-      output[idx] =
-          (scaling_factor[c] * post_qtz_factor) * static_cast<T_FLOAT>(out);
-    }
+  if (ncp.output_channels > b) {
+      Measurement::Start("QuantizedConv2D_ChangeOutputLayout");
+      // XXX: assumes that ncp.output_channels % b == 0
+      int out_index = 0;
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int s = 0; s < ncp.output_channels / b; s++)
+      for (int d = 0; d < b; d++) {
+        auto buf_index = h * (b * ncp.output_width) + w * b + s * (ncp.output_height * ncp.output_width * b) + d;
+        output[out_index++] = static_cast<float>(p.device_output_buf[buf_index]);
+      }
+      Measurement::Stop();
+
+      // write_to_file((std::string("out/") + p.debug_name).c_str(), 0, output, out_elems * p.normal_conv_params.output_channels);
+
+      Measurement::Start("QuantizedConv2D_ApplyScalingFactor");
+      for (unsigned i = 0; i < out_elems; ++i) {
+        for (unsigned c = 0; c < out_channels; c++) {
+          unsigned idx = i * out_channels + c;
+          output[idx] = (scaling_factor[c] * post_qtz_factor) * output[idx];
+        }
+      }
+      Measurement::Stop();
+  }
+  else {
+      Measurement::Start("QuantizedConv2D_RemoveChannels");
+      int tmp_index = 0;
+      auto* tmp_output = new T_FLOAT[out_elems * p.normal_conv_params.output_channels];
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int d = 0; d < ncp.output_channels; d++) {
+        tmp_output[tmp_index++] = p.device_output_buf[h * (tca_channels * ncp.input_width) + w * tca_channels + d];
+      }
+
+      // write_to_file((std::string("out/") + p.debug_name).c_str(), 0, tmp_output, out_elems * p.normal_conv_params.output_channels);
+      delete [] tmp_output;
+      Measurement::Stop();
+
+      Measurement::Start("QuantizedConv2D_ApplyScalingFactor");
+      int out_index = 0;
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int d = 0; d < ncp.output_channels; d++)
+        output[out_index++] = (scaling_factor[d] * post_qtz_factor) * p.device_output_buf[h * (tca_channels * ncp.input_width) + w * tca_channels + d];
+      Measurement::Stop();
   }
 
+  //// write_to_file("out/qconv_output_16bit_ol2_final_", out_counter_final++, output, out_elems * p.normal_conv_params.output_channels);
   Measurement::Stop();
+
+
 }
 
-void func_QuantizedConv2DWithThreshold(QUANTIZED_NOT_PACKED input[],
+void func_QuantizedConv2DWithThreshold(QUANTIZED_PACKED input[],
                                        QUANTIZED_PACKED_KERNEL kernel[],
-                                       QUANTIZED_NOT_PACKED output[],
+                                       QUANTIZED_PACKED output[],
                                        T_FLOAT scaling_factor,
                                        binary_convolution_parameters p) {
+
+  auto& ncp(p.normal_conv_params);
+
+  unsigned in_elems = ncp.input_height * ncp.input_width * ncp.kernel_depth;
+  unsigned out_elems = ncp.output_height * ncp.output_width * ncp.output_channels;
+
+  // int b = 32;
+  // int packed_input_depth = (ncp.kernel_depth / 32) * 2;
+  // int packed_b = (b / 32) * 2;
+
+  const T_UINT b = 32;
+  const T_UINT out_c = ((ncp.output_channels + b - 1) / b) * b;
+  int packed_output_depth = (out_c / 32) * 2;
+  int packed_b = (b / 32) * 2;
+
+
+  // TODO: replace input with 'input_tca_layout' when ready
   QuantizedConv2D(input, kernel, p);
+  if (ncp.output_channels > b) {
 
-  unsigned out_elems = p.normal_conv_params.output_height *
-                       p.normal_conv_params.output_width *
-                       p.normal_conv_params.output_channels;
+      Measurement::Start("QuantizedConv2D_ChangeOutputLayout");
+      // XXX: assumes that ncp.output_channels % b == 0
+      int out_index = 0;
+      for (int h = 0; h < ncp.output_height; h++)
+      for (int w = 0; w < ncp.output_width; w++)
+      for (int s = 0; s < out_c / b; s++)
+      for (int d = 0; d < packed_b; d++) {
+        auto buf_index = h * (packed_b * ncp.output_width) + w * packed_b + s * (ncp.output_height * ncp.output_width * packed_b) + d;
+        output[out_index++] = QUANTIZED_PACKED(reinterpret_cast<volatile int32_t*>(p.device_output_buf)[buf_index]);
+      }
+      Measurement::Stop();
 
-  for (unsigned i = 0; i < out_elems; ++i) {
-    output[i] = p.device_output_buf[i];
+      // write_to_file((std::string("out/") + p.debug_name).c_str(), 0, output, out_elems * p.normal_conv_params.output_channels);
+  }
+  else {
+      Measurement::Start("Copy");
+      int tmp_index = 0;
+      int number_of_elements = ncp.output_height * ncp.output_width * packed_output_depth;
+
+      for (int i = 0; i < number_of_elements; i++) {
+        output[i] = QUANTIZED_PACKED(reinterpret_cast<volatile int32_t*>(p.device_output_buf)[i]);
+      }
+
+
+      // write_to_file((std::string("out/") + p.debug_name).c_str(), 0, tmp_output, out_elems * p.normal_conv_params.output_channels);
+      Measurement::Stop();
   }
 }
 
-void func_QuantizedConv2DWithThreshold(QUANTIZED_NOT_PACKED input[],
+void func_QuantizedConv2DWithThreshold(QUANTIZED_PACKED input[],
                                        QUANTIZED_PACKED_KERNEL kernel[], T_FLOAT output[],
                                        T_FLOAT scaling_factor,
                                        binary_convolution_parameters p) {
@@ -167,19 +286,47 @@ void func_QuantizedConv2DWithThreshold(QUANTIZED_NOT_PACKED input[],
                        p.normal_conv_params.output_channels);
 }
 
-void func_QuantizedConv2DWithThreshold(QUANTIZED_NOT_PACKED input[],
+void func_QuantizedConv2DWithThreshold(QUANTIZED_PACKED input[],
                                        QUANTIZED_PACKED_KERNEL kernel[],
-                                       QUANTIZED_NOT_PACKED output[],
+                                       QUANTIZED_PACKED output[],
                                        T_FLOAT scaling_factor[],
                                        binary_convolution_parameters p) {
   func_QuantizedConv2DWithThreshold(input, kernel, output, scaling_factor[0],
                                     p);
 }
 
-void func_QuantizedConv2DWithThreshold(QUANTIZED_NOT_PACKED input[],
+void func_QuantizedConv2DWithThreshold(QUANTIZED_PACKED input[],
                                        QUANTIZED_PACKED_KERNEL kernel[], T_FLOAT output[],
                                        T_FLOAT scaling_factor[],
                                        binary_convolution_parameters p) {
   func_QuantizedConv2DWithThreshold(input, kernel, output, scaling_factor[0],
                                     p);
+}
+
+
+void func_Lookup(float *input, QUANTIZED_PACKED_KERNEL *lsb, QUANTIZED_PACKED_KERNEL *msb, QUANTIZED_PACKED* output, int h, int w, int c) {
+
+  int b = 32;
+  int packed_depth = 2;
+  Measurement::Start("Lookup");
+
+  int out_idx = 0;
+  for(int ih = 0; ih < h; ih++)
+  for(int iw = 0; iw < w; iw++) {
+    int r = int(input[ih * w * 3 + iw * 3 + 0] * 255.0);
+    int g = int(input[ih * w * 3 + iw * 3 + 1] * 255.0);
+    int b = int(input[ih * w * 3 + iw * 3 + 2] * 255.0);
+
+    auto r_lsb = lsb[r];
+    auto g_lsb = lsb[g];
+    auto b_lsb = lsb[b];
+    auto r_msb = msb[r];
+    auto g_msb = msb[g];
+    auto b_msb = msb[b];
+
+    output[out_idx++] = QUANTIZED_PACKED((b_lsb.Raw() << 20) | (g_lsb.Raw() << 10) | r_lsb.Raw());
+    output[out_idx++] = QUANTIZED_PACKED((b_msb.Raw() << 20) | (g_msb.Raw() << 10) | r_msb.Raw());
+  }
+
+  Measurement::Stop();
 }

--- a/dlk/python/dlk/templates/src/network.tpl.cpp
+++ b/dlk/python/dlk/templates/src/network.tpl.cpp
@@ -46,6 +46,7 @@ limitations under the License.
 #include "func/sqrt.h"
 #include "func/sub.h"
 #include "func/unpooling.h"
+#include "func/lookup.h"
 #include "operators.h"
 #include "quantizer.h"
 #include "network.h"

--- a/dlk/python/dlk/templates/src/network.tpl.cpp
+++ b/dlk/python/dlk/templates/src/network.tpl.cpp
@@ -68,6 +68,21 @@ limitations under the License.
 #include <unistd.h>
 #endif
 
+namespace {
+
+uint8_t* mapPhysicalMemory(size_t base, size_t size) {
+    int fd = open("/dev/mem", O_RDWR | O_SYNC, 0);
+    if (fd == -1)
+        throw std::system_error(errno, std::generic_category());
+    int rw = PROT_READ | PROT_WRITE;
+    auto* mapped_base = reinterpret_cast<uint8_t*>(mmap(nullptr, size, rw, MAP_SHARED, fd, base));
+    if (mapped_base == MAP_FAILED)
+        throw std::system_error(errno, std::generic_category());
+    return mapped_base;
+}
+
+} // namespace
+
 {% if config.debug -%}
 #include "c2numpy.h"
 
@@ -241,6 +256,14 @@ bool Network::init()
   {% endif %}
   {%- endfor %}
   {{ '\n' -}}
+
+#if defined RUN_ON_FPGA
+  auto* kernel_buffer = mapPhysicalMemory(KERNEL_ADDR, total_kernel_size); 
+  {% for qconv in graph.convs(quantized_only=True) -%}
+  {%    set kernel = qconv.input_nodes[1] -%}
+  std::memcpy(kernel_buffer + {{qconv.name}}_kernel_offset, {{kernel.name}}, {{qconv.name}}_kernel_size);
+  {% endfor -%}
+#endif // RUN_ON_FPGA
 
   return true;
 }

--- a/dlk/python/dlk/templates/src/pack_input_to_qwords.cpp
+++ b/dlk/python/dlk/templates/src/pack_input_to_qwords.cpp
@@ -12,83 +12,60 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
+#include <limits.h>
 #include "global.h"
 #include "pack_input_to_qwords.h"
 #include "pack2bits.h"
 #include "operators.h" // FIXME(nikolay): for convolution_parameters definition, rid of it later
 #include "time_measurement.h"
 
-void pack_input_to_qwords(QUANTIZED_NOT_PACKED input[],
-                          QUANTIZED_PACKED output[],
-                          unsigned int len,
-                          unsigned int input_bitwidth)
-{
-  Measurement::Start("pack_input_to_qwords");
+int pack_input(QUANTIZED_NOT_PACKED input[], size_t input_height, size_t input_width, size_t input_depth,
+  size_t bits_per_input, QUANTIZED_PACKED output[]) {
 
-  #ifdef USE_NEON
-    if (len % 16 == 0) {
+  Measurement::Start("pack_input");
+  const int bits_per_word = sizeof(QUANTIZED_PACKED) * CHAR_BIT;
+  int full_words_in_depth = input_depth / bits_per_word;
+  int remainder_bits_in_depth = input_depth % bits_per_word;
+  int input_index = 0;
+  int current_word = 0;
+
+  auto len = input_height * input_width * input_depth;
+  if (input_depth % 32 == 0) {
       pack2bits(input, output, (int)len);
       Measurement::Stop();
-      return;
-    }
-  #endif
+      return 0;
+  }
 
-  unsigned idx_in = 0;
-  unsigned idx_out = 0;
-  unsigned bit_count = 0;
+  for (int h = 0; h < input_height; ++h)
+      for (int w = 0; w < input_width; ++w) {
+          for (int d = 0; d < full_words_in_depth; ++d) {
+              output[current_word] = QUANTIZED_PACKED(0);
+              output[current_word + 1] = QUANTIZED_PACKED(0);
+              for (int d = 0; d < bits_per_word; ++d) {
+                for(int b = 0; b < bits_per_input; ++b)
+                  output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] & (1 << b)) >> b) << d);
+                input_index++;
+              }
+              current_word += bits_per_input;
+          }
 
-  static QUANTIZED_PACKED::T qinput_words_buf[MAX_NBIT_QINPUT] = {}; // must be initialized
+          if(!remainder_bits_in_depth)
+              continue;
 
-  for (idx_in = 0; idx_in + 3 < len; idx_in += 4) {
-    QUANTIZED_PACKED::T t = ((QUANTIZED_PACKED::T*)(&input[idx_in]))[0];
-    QUANTIZED_PACKED::T b0 = (t & 0x00000001)
-      | ((t & 0x01000000) >> 21)
-      | ((t & 0x00010000) >> 14)
-      | ((t & 0x00000100) >> 7);
-    QUANTIZED_PACKED::T b1 = ((t & 0x02000000) >> 22)
-      | ((t & 0x00020000) >> 15)
-      | ((t & 0x00000200) >> 8)
-      | ((t & 0x00000002) >> 1);
-
-    qinput_words_buf[0] |= (b0 << bit_count);
-    qinput_words_buf[1] |= (b1 << bit_count);
-    bit_count += 4;
-
-    if (bit_count == QUANTIZED_PACKED::BitCount)
-      {
-        for (unsigned i_bit = 0; i_bit < input_bitwidth; i_bit++) {
-          output[idx_out++] = QUANTIZED_PACKED(qinput_words_buf[i_bit]);
-          qinput_words_buf[i_bit] = 0;
-        }
-
-        bit_count = 0;
+          output[current_word] = QUANTIZED_PACKED(0);
+          output[current_word + 1] = QUANTIZED_PACKED(0);
+          for (int d = 0; d < remainder_bits_in_depth; ++d) {
+             for(int b = 0; b < bits_per_input; ++b)
+               output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] & (1 << b)) >> b) << d);
+             input_index++;
+          }
+          current_word += bits_per_input;
       }
-  }
-
-  // Remainder
-  {
-    for (; idx_in < len; idx_in++) {
-      QUANTIZED_NOT_PACKED tmp_input = input[idx_in];
-      QUANTIZED_PACKED::T b0 = tmp_input & 0x1;
-      QUANTIZED_PACKED::T b1 = (tmp_input & 0x2) >> 1;
-
-      qinput_words_buf[0] |= (b0 << bit_count);
-      qinput_words_buf[1] |= (b1 << bit_count);
-      ++bit_count;
-    }
-
-    for (unsigned i_bit = 0; i_bit < input_bitwidth; i_bit++) {
-      output[idx_out++] = QUANTIZED_PACKED(qinput_words_buf[i_bit]);
-      // FIX ME (cannot delete below line now,
-      // later change implementation to use two register because input_bitwidth is always 2.)
-      qinput_words_buf[i_bit] = 0;
-    }
-  }
 
   Measurement::Stop();
-}
 
+  return current_word;
+}
 
 void pack_input_to_qwords(
   QUANTIZED_NOT_PACKED input[],
@@ -98,5 +75,7 @@ void pack_input_to_qwords(
   struct convolution_parameters& p = bcp.normal_conv_params;
   unsigned kernel_elems = p.kernel_height * p.kernel_width * p.kernel_depth;
   unsigned im2col_input_elems = p.output_height * p.output_width * kernel_elems;
-  pack_input_to_qwords(input, output, im2col_input_elems, bcp.bin_input_bitwidth);
+
+  pack_input(input, bcp.normal_conv_params.input_height, bcp.normal_conv_params.input_width,
+    bcp.normal_conv_params.kernel_depth, bcp.bin_input_bitwidth, output);
 }

--- a/dlk/python/dlk/templates/src/pack_input_to_qwords.cpp
+++ b/dlk/python/dlk/templates/src/pack_input_to_qwords.cpp
@@ -43,7 +43,7 @@ int pack_input(QUANTIZED_NOT_PACKED input[], size_t input_height, size_t input_w
               output[current_word + 1] = QUANTIZED_PACKED(0);
               for (int d = 0; d < bits_per_word; ++d) {
                 for(int b = 0; b < bits_per_input; ++b)
-                  output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] & (1 << b)) >> b) << d);
+                  output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] >> b) & 1) << d);
                 input_index++;
               }
               current_word += bits_per_input;
@@ -56,7 +56,7 @@ int pack_input(QUANTIZED_NOT_PACKED input[], size_t input_height, size_t input_w
           output[current_word + 1] = QUANTIZED_PACKED(0);
           for (int d = 0; d < remainder_bits_in_depth; ++d) {
              for(int b = 0; b < bits_per_input; ++b)
-               output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] & (1 << b)) >> b) << d);
+               output[current_word + b] = QUANTIZED_PACKED(output[current_word + b].Raw() | ((input[input_index] >> b) & 1) << d);
              input_index++;
           }
           current_word += bits_per_input;

--- a/dlk/python/dlk/templates/src/time_measurement.cpp
+++ b/dlk/python/dlk/templates/src/time_measurement.cpp
@@ -13,10 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
+
 #include "time_measurement.h"
 
 std::map<std::string, std::vector<Measurement::measure> > Measurement::times;
 std::vector<std::string> Measurement::current_context;
+std::vector<Measurement::Node*> Measurement::stack;
+std::vector<std::unique_ptr<Measurement::Node>> Measurement::roots;
 
 
 void Measurement::Start(const std::string &measure_name)
@@ -25,6 +29,25 @@ void Measurement::Start(const std::string &measure_name)
   measure m;
   m.start = std::chrono::system_clock::now();
   m.end = std::chrono::system_clock::time_point();
+
+  if (stack.empty()) {
+      roots.emplace_back(std::make_unique<Node>(measure_name, 0));
+      auto* current = roots.back().get();
+      current->measurements.emplace_back(m);
+      stack.emplace_back(current);
+  }
+  else {
+      auto* parent = stack.back();
+      auto it = parent->children.find(measure_name);
+      if (it == parent->children.end()) {
+        it = parent->children.emplace(std::piecewise_construct,
+          std::forward_as_tuple(measure_name),
+          std::forward_as_tuple(std::make_unique<Node>(measure_name, parent->children.size()))).first;
+      }
+      auto* current = it->second.get();
+      current->measurements.emplace_back(m);
+      stack.emplace_back(current);
+  }
 
   times[measure_name].push_back(m);
   current_context.push_back(measure_name);
@@ -39,6 +62,14 @@ void Measurement::Stop()
     std::cout << "ERROR: wrong Start/Stop pairs" << std::endl;
     return;
   }
+
+  if (stack.empty()) {
+    std::cout << "ERROR: wrong Start/Stop pairs" << std::endl;
+    return;
+  }
+
+  stack.back()->measurements.back().end = std::chrono::system_clock::now();
+  stack.pop_back();
 
   times[current_context.back()].back().end = std::chrono::system_clock::now();
   current_context.pop_back();
@@ -61,5 +92,32 @@ void Measurement::Report()
     std::cout << "  sum:" << sum / 1000 << "ms";
     std::cout << std::endl;
   }
+
+  std::cout << "---------------------------------------------------" << std::endl;
+  for (auto& root: roots) {
+    DumpTimeTree(*root, 0);
+  }
   #endif
+}
+
+void Measurement::DumpTimeTree(const Node& node, int level) {
+    std::cout << std::string(level * 2, '.') << node.name << " ";
+    double sum = 0.0;
+    for (auto& m : node.measurements) {
+      double t = std::chrono::duration_cast<TIME_ORDER>(m.end - m.start).count();
+      std::cout << t << ",";
+      sum += t;
+    }
+    std::cout << "  sum:" << sum / 1000 << "ms";
+    std::cout << std::endl;
+    std::vector<const Node*> sorted;
+    for (auto& p : node.children) {
+      sorted.emplace_back(p.second.get());
+    }
+    std::sort(sorted.begin(), sorted.end(), [](auto* a, auto* b) {
+      return a->position < b->position;
+    });
+    for (auto* child : sorted) {
+      DumpTimeTree(*child, level + 1);
+    }
 }

--- a/dlk/python/dlk/templates/src/write_to_file.cpp
+++ b/dlk/python/dlk/templates/src/write_to_file.cpp
@@ -1,0 +1,53 @@
+#include "global.h"
+#include <string>
+#include <fstream>
+
+void write_to_file(const char *filename, int id, volatile int32_t* data, int size) {
+  std::string name(filename);
+  name += std::to_string(id);
+
+  std::ofstream outfile(name);
+  outfile << __FUNCTION__ << " int32" << std::endl;
+  for(int i = 0; i < size; i++)
+    outfile << i << "," << data[i] << std::endl;
+  outfile.flush();
+  outfile.close();
+}
+
+void write_to_file(const char *filename, int id, BIN_CONV_OUTPUT* data, int size) {
+  std::string name(filename);
+  name += std::to_string(id);
+
+  std::ofstream outfile(name);
+  outfile << __FUNCTION__ << " BIN_CONV_OUTPUT" << std::endl;
+  for(int i = 0; i < size; i++)
+    outfile << i << "," << data[i] << std::endl;
+  outfile.flush();
+  outfile.close();
+}
+
+
+void write_to_file(const char *filename, int id, QUANTIZED_NOT_PACKED* data, int size) {
+  std::string name(filename);
+  name += std::to_string(id);
+
+  std::ofstream outfile(name);
+  outfile << __FUNCTION__ << " QUANTIZED_NOT_PACKED" << std::endl;
+  for(int i = 0; i < size; i++)
+    outfile << i << "," << (int) data[i] << std::endl;
+  outfile.flush();
+  outfile.close();
+}
+
+
+void write_to_file(const char *filename, int id, float* data, int size) {
+  std::string name(filename);
+  name += std::to_string(id);
+
+  std::ofstream outfile(name);
+  outfile << __FUNCTION__ << " float" << std::endl;
+  for(int i = 0; i < size; i++)
+    outfile << i << "," << data[i] << std::endl;
+  outfile.flush();
+  outfile.close();
+}

--- a/lmnet/lmnet/utils/config.py
+++ b/lmnet/lmnet/utils/config.py
@@ -274,7 +274,7 @@ def display(config):
 def copy_to_experiment_dir(config_file):
     # copy config file to the experiment directory
     saved_config_file_path = _config_file_path_to_copy(config_file)
-    gfile.Copy(config_file, saved_config_file_path)
+    gfile.Copy(config_file, saved_config_file_path, overwrite=True)
 
 
 def init_config(config, training_id, recreate=False):


### PR DESCRIPTION
Add supports for TCAv2.

## Motivation and Context
TCAv2 will be released soon as part of Blueoil.

## Description

**Data layout changes**

Activations (inference: N=1) | Before | After
-- | -- | --
Rank | 3 | 4
Layout | H x W x C | C(b) x H x W x b

Kernels | Before | After
-- | -- | --
Rank | 4 | 6
Layout | O x H x W x C | O(b) x C(b) x H x W x b(O) x b(C)

where:
 - b is the famous TCA parameter.
 - H is height
 - W is width
 - C are input channels
 - O are output channels
 - C(b) stands for the input channel dimension divided in blocks of size b
 - O(b) stands for the output channel dimension divided in blocks of size b
 - b(O) stands for size b following the output channel direction
 - b(C) stands for size b following the input channel direction


**Tensorflow importer (tf.py)**
* 7 new operators to import: Gather, Unique, Cast, Minimum, StridedSlice, Prod, Shape
* 4 of these operators has 2 inputs: Gather, Minimum, Reshape and Prod
* 1 of them has four inputs: StridedSlice
* Some operators has undefined shape (to be inferred at run time)

**View.py**
* Physical addresses of each layer’s kernels are passed to the runtime (we now copy each kernel to the raw memory in advance during the initialization of the runtime)

**Data_types.py**
 * Added missing class which represents QUANTIZED_PACKED data type

**Operators.py**
* Fix reshaped operator: missing shape parameter

**Optimizer.py**
* _transpose_kernels() function is not used anymore (deleted)
* Pass_propagate_quantization_details_into_conv recognizes Lookup as a quantizer
* Pass_pack_weights now change the layout of the TensorFlow kernels to TCAv2 kernel order. It also pads in the output channel direction for the cases where the number of output channels is not a multiple of b. The codification of the kernel values is also inverted.
* pass_quantize_convolutions() now set the data type of the quantized convolutions to QUANTIZED_PACKED.

**C++ (runtime)**
* Time measurement reports for the debugging executable are now printed hierarchically
* pack_input_to_qwords() supports padding on the input channels dimension
* Network.cpp: Init() function now copy all the kernels to the raw memory during initialization time
* Added TCAConv2d() function which changes the layout of the inputs and then calls TCAv2 with de10_nano::RunTCA()
* ConcatV2 and Space2Depth operators now expect quantized inputs
* Quantizer func_QTZ_linear_mid_tread_half() function now outputs quantized values
* func_QuantizedConv2D() function now acceptsQUANTIZED_PACKED() input values


## How has this been tested?
Only for the FPGA target. Confirmed to work on DE10 Nano with TCAv2.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
