### PR TITLE
Enable data prefetch for param tuner

### DIFF
--- a/lmnet/configs/core/segmentation/segnet_quantize_camvid_tune.py
+++ b/lmnet/configs/core/segmentation/segnet_quantize_camvid_tune.py
@@ -130,5 +130,4 @@ DATASET.AUGMENTOR = Sequence([
     Hue((-10, 10)),
 ])
 
-# TODO(Neil): dataset pre-fectch is not supported at the moment
 DATASET.ENABLE_PREFETCH = False

--- a/lmnet/executor/tune_ray.py
+++ b/lmnet/executor/tune_ray.py
@@ -135,7 +135,7 @@ def setup_dataset(config, subset, rank):
     dataset_class = config.DATASET_CLASS
     dataset_kwargs = dict((key.lower(), val) for key, val in config.DATASET.items())
     dataset = dataset_class(subset=subset, **dataset_kwargs)
-    enable_prefetch = dataset_kwargs.pop("enable_prefetch", False)
+    enable_prefetch = dataset_kwargs.pop("enable_prefetch", False) if subset == 'train' else False
     return DatasetIterator(dataset, seed=rank, enable_prefetch=enable_prefetch)
 
 

--- a/lmnet/executor/tune_ray.py
+++ b/lmnet/executor/tune_ray.py
@@ -135,6 +135,8 @@ def setup_dataset(config, subset, rank):
     dataset_class = config.DATASET_CLASS
     dataset_kwargs = dict((key.lower(), val) for key, val in config.DATASET.items())
     dataset = dataset_class(subset=subset, **dataset_kwargs)
+    # TODO (Neil): Enable both train and validation
+    # For some reasons processes are not terminated cleanly, enable prefetch ONLY for the train dataset.
     enable_prefetch = dataset_kwargs.pop("enable_prefetch", False) if subset == 'train' else False
     return DatasetIterator(dataset, seed=rank, enable_prefetch=enable_prefetch)
 


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Previously the processes would not terminate cleanly when the `DATASET.ENABLE_PREFETCH` is `True`, and cause the trial cue to halt. This is a quick fix to avoid the problem by only enable the data prefetch for the training of the parameter tuner.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
