### PR TITLE
Fix data for tiling when using Lookup

### DIFF
--- a/dlk/python/dlk/core/optimizer.py
+++ b/dlk/python/dlk/core/optimizer.py
@@ -416,7 +416,7 @@ def pass_pack_weights(graph: Graph) -> None:
                         kn2row_output[out_index] = padded_data[idx]
                         out_index += 1
 
-        op_data = weight_quantizer.binarizer(weight_quantizer.data)
+        op_data = weight_quantizer.binarizer(padded_data)
         data = packer.run(op_data.astype(np.float32), weight_quantizer.dimension)
 
         tca_binarized_data = weight_quantizer.binarizer(tca_output)


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
Generating kernel data for 32bit arm is broken when use lookup.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
When use lookup, number of input channel is not multiple of 32.
This case wrong data generation.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
- Fix data generation for tiling

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
```shell
$ PYTHONPATH=python/dlk python python/dlk/scripts/generate_project.py -i minimal_graph_with_shape.pb -o tmp/ -p classification -hq -ts
$ cd tmp/classification.prj
$ make -j8 lm_arm
```
and run `lm_arm.elf` on DE-10 Nano.

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
