### PR TITLE
Updated Reshape operator with a default value.

### DIFF
--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -1883,7 +1883,12 @@ class Reshape(Operator):
     _input_names = ['data', 'shape']
     _output_names = ['reshaped']
 
-    def __init__(self, name: str, shape: List[int], dtype: DataType, input_ops: Ops, dimension_format: str) -> None:
+    def __init__(self,
+                 name: str,
+                 shape: List[int],
+                 dtype: DataType,
+                 input_ops: Ops,
+                 dimension_format: str = 'NHWC') -> None:
         """Init the reshape operator."""
         super().__init__(name, shape, dtype, input_ops, dimension_format=dimension_format)
 

--- a/dlk/python/dlk/templates/include/network.tpl.h
+++ b/dlk/python/dlk/templates/include/network.tpl.h
@@ -83,7 +83,7 @@ private:
   const uint32_t {{qconv.name}}_kernel_offset = {{offset.o}};
   {%    set offset.o = offset.o + size -%}
   {% endfor -%}
-  const uint32_t total_kernel_size = {{offset.o}};
+  const uint32_t total_kernel_size = std::max(1, {{offset.o}});
 #endif // RUN_ON_FPGA
 };
 

--- a/dlk/tests/test_optimizer.py
+++ b/dlk/tests/test_optimizer.py
@@ -323,7 +323,7 @@ class TestPassQuantizeConvolutions(unittest.TestCase):
 
         pass_quantize_convolutions(graph1)
 
-        self.assertEqual(graph1.get_op('aqtz1').dtype, QUANTIZED_NOT_PACKED(),
+        self.assertEqual(graph1.get_op('aqtz1').dtype, QUANTIZED_PACKED(),
                          '[Failed] Found output dtype of activation quantizer not proper')
         self.assertEqual(graph1.get_op('kqtz1').dtype, PackedUint32(),
                          '[Failed] Found output dtype of kernel quantizer not proper')

--- a/dlk/tests/test_optimizer.py
+++ b/dlk/tests/test_optimizer.py
@@ -15,7 +15,7 @@
 # =============================================================================
 """Test file for Optimizer."""
 import unittest
-from core.data_types import Float32, PackedUint32, Int32, QUANTIZED_NOT_PACKED
+from core.data_types import Float32, PackedUint32, Int32, QUANTIZED_PACKED
 from core.optimizer import pass_remove_identities, pass_transpose, pass_constant_folding, \
     pass_propagate_quantization_details_into_conv, pass_compute_thresholds, pass_pack_weights, \
     pass_quantize_convolutions, pass_propagate_datatypes, pass_propagate_output_type_backward
@@ -374,7 +374,7 @@ class TestPassPropagateDatatypes(unittest.TestCase):
 
         pass_propagate_datatypes(graph1)
 
-        self.assertEqual(graph1.get_op('s2d').dtype, QUANTIZED_NOT_PACKED(),
+        self.assertEqual(graph1.get_op('s2d').dtype, QUANTIZED_PACKED(),
                          '[Failed] Found dtype of SpaceToDepth not propagate correctly')
 
         print("Test pass #6 propagate data types passed!")
@@ -388,7 +388,7 @@ class TestPassPropagateDatatypes(unittest.TestCase):
 
         # Conv1
         w1 = Constant('weight1', Float32(), data1)
-        conv1 = Conv('conv1', [1, 4, 4, 3], QUANTIZED_NOT_PACKED(), {'X': x, 'W': w1}, kernel_shape=[2, 2])
+        conv1 = Conv('conv1', [1, 4, 4, 3], QUANTIZED_PACKED(), {'X': x, 'W': w1}, kernel_shape=[2, 2])
 
         pool1 = SpaceToDepth('s2d', [1, 2, 2, 12], Float32(), {'input': conv1})
 
@@ -424,7 +424,7 @@ class TestPassPropagateOutputTypeBackward(unittest.TestCase):
 
         # Conv1
         w1 = Constant('weight1', Float32(), data1)
-        conv1 = Conv('conv1', [1, 4, 4, 3], QUANTIZED_NOT_PACKED(), {'X': x, 'W': w1}, kernel_shape=[2, 2])
+        conv1 = Conv('conv1', [1, 4, 4, 3], QUANTIZED_PACKED(), {'X': x, 'W': w1}, kernel_shape=[2, 2])
         conv1.is_quantized = True
 
         pool1 = SpaceToDepth('s2d', [1, 2, 2, 12], Float32(), {'input': conv1})


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Fixed Jenkins test failing here: https://github.com/blue-oil/blueoil/pull/313

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
dimension_format for Reshape had no default value and there were several
places which used it without providing one. I opted for setting
a default value rather than updating all places to supply
one of their own. Not sure why something like Reshape needs
this parameter though; seems like the superclass requires it so
we have it in Reshape as a consequence. If that is the only reason,
removing it from the Reshape constructor and using the
superclass's default would be better.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
Ran `make test-dlk` on my own DE10-Nano and all test passed.

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
