### PR TITLE
Fixed unsigned to signed integer conversion issue.

### DIFF
--- a/dlk/python/dlk/templates/include/func/quantized_conv2d.h
+++ b/dlk/python/dlk/templates/include/func/quantized_conv2d.h
@@ -34,13 +34,13 @@ void QuantizedConv2D(const TensorView<T, layout>& input,
   Measurement::Start("QuantizedConv2D");
 
   constexpr T_UINT TilingInTypeBitWidth = dlk::impl::tiling_input_elem_t::BitCount;
-  int kh = p.normal_conv_params.kernel_height;
-  int kw = p.normal_conv_params.kernel_width;
-  int padding = p.normal_conv_params.padding;
-  int ih = p.normal_conv_params.input_height;
-  int iw = p.normal_conv_params.input_width;
-  int ic = p.normal_conv_params.kernel_depth;
-  int oc = p.normal_conv_params.output_channels;
+  T_UINT kh = p.normal_conv_params.kernel_height;
+  T_UINT kw = p.normal_conv_params.kernel_width;
+  T_UINT padding = p.normal_conv_params.padding;
+  T_UINT ih = p.normal_conv_params.input_height;
+  T_UINT iw = p.normal_conv_params.input_width;
+  T_UINT ic = p.normal_conv_params.kernel_depth;
+  T_UINT oc = p.normal_conv_params.output_channels;
   auto size = oc * ih * iw;
   if (p.device_output_buf == nullptr)
     p.device_output_buf = new BIN_CONV_OUTPUT[size]();

--- a/dlk/python/dlk/templates/include/operators.h
+++ b/dlk/python/dlk/templates/include/operators.h
@@ -52,7 +52,7 @@ struct binary_convolution_parameters {
     }
   }
   BIN_CONV_OUTPUT *thresholds;
-  T_INT n_bit;
+  T_UINT n_bit;
   T_FLOAT max_value;
   unsigned long device_input_phys_addr;
   unsigned long device_output_phys_addr;

--- a/dlk/python/dlk/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
+++ b/dlk/python/dlk/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
@@ -36,14 +36,14 @@ void QuantizedConv2DKn2Row(const kn2row_input_t& input,
                                   const binary_convolution_parameters &p) {
   using namespace dlk;
 
-  int ic = p.normal_conv_params.kernel_depth;
-  int ih = p.normal_conv_params.input_height;
-  int iw = p.normal_conv_params.input_width;
-  int oc = p.normal_conv_params.output_channels;
-  int oh = p.normal_conv_params.output_height;
-  int ow = p.normal_conv_params.output_width;
-  int kh = p.normal_conv_params.kernel_height;
-  int kw = p.normal_conv_params.kernel_width;
+  T_UINT ic = p.normal_conv_params.kernel_depth;
+  T_UINT ih = p.normal_conv_params.input_height;
+  T_UINT iw = p.normal_conv_params.input_width;
+  T_UINT oc = p.normal_conv_params.output_channels;
+  T_UINT oh = p.normal_conv_params.output_height;
+  T_UINT ow = p.normal_conv_params.output_width;
+  T_UINT kh = p.normal_conv_params.kernel_height;
+  T_UINT kw = p.normal_conv_params.kernel_width;
 
   assert(ih * iw == oh * ow);
   assert(MAX_SIZE_IM2COL_INPUTS_PER_LAYER >= ic * kh * kw * ih * iw);


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
When running tests a lot of warning regarding `unsigned int` to `int` and vice-versa conversion appear. This makes the error log much harder to read, and in general it would be best to not have errors, by either muting(marking as not an error) them or fixing them.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Changed 2 places where we assigned `T_UINT` to `int` for some reason. Explicit usage of `unsigned int` might be desired here, but I am not sure. To be honest, I have no clue why we have `T_UINT` and the like.

Also fixed `n_bits` being `T_INT`. I assume this is to show how many bits we are using, which I believe cannot be negative.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

Local run of `make test-dlk`.

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
