### PR TITLE
Removed unused generate_consts.

### DIFF
--- a/dlk/python/dlk/code_generater.py
+++ b/dlk/python/dlk/code_generater.py
@@ -70,26 +70,6 @@ class CodeGenerater(object):
                 else:
                     shutil.copy2(src_file_path, dest_file_path)
 
-    def generate_consts(self) -> None:
-        const_src_dir_path = path.join(self.src_dir, 'consts')
-        const_header_dir_path = path.join(self.header_dir, 'consts')
-        utils.make_dirs([const_src_dir_path, const_header_dir_path])
-
-        const_src_template_path = path.join('manual', 'input', 'const.tpl.cpp')
-        const_header_template_path = path.join('manual', 'input', 'const.tpl.h')
-
-        for const in self.graph.consts:
-
-            self.template.generate(const_src_template_path,
-                                   const_src_dir_path,
-                                   new_name=const.name,
-                                   const=const)
-
-            self.template.generate(const_header_template_path,
-                                   const_header_dir_path,
-                                   new_name=const.name,
-                                   const=const)
-
     def generate_inputs(self) -> None:
         input_src_dir_path = path.join(self.src_dir, 'inputs')
         input_header_dir_path = path.join(self.header_dir, 'inputs')


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
https://github.com/blue-oil/blueoil/issues/314

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
I am pretty sure `generate_consts()` is an old thing we used to handle consts, and have switched to a different method with a different folder with several files of consts.

`grep "generate_consts" -r .` produces only `./dlk/python/dlk/code_generater.py:    def generate_consts(self) -> None:`, which makes we think it is not used. There may still be the possibility that it is called via some Python magic somewhere, but Jenkins tests should be sufficient to cover that.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
Jenkins.
It's an unused function, so don't see much testing that can be done.

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue) (Maybe?)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
