### PR TITLE
Remove consts into master

### DIFF
--- a/dlk/python/dlk/code_generater.py
+++ b/dlk/python/dlk/code_generater.py
@@ -70,26 +70,6 @@ class CodeGenerater(object):
                 else:
                     shutil.copy2(src_file_path, dest_file_path)
 
-    def generate_consts(self) -> None:
-        const_src_dir_path = path.join(self.src_dir, 'consts')
-        const_header_dir_path = path.join(self.header_dir, 'consts')
-        utils.make_dirs([const_src_dir_path, const_header_dir_path])
-
-        const_src_template_path = path.join('manual', 'input', 'const.tpl.cpp')
-        const_header_template_path = path.join('manual', 'input', 'const.tpl.h')
-
-        for const in self.graph.consts:
-
-            self.template.generate(const_src_template_path,
-                                   const_src_dir_path,
-                                   new_name=const.name,
-                                   const=const)
-
-            self.template.generate(const_header_template_path,
-                                   const_header_dir_path,
-                                   new_name=const.name,
-                                   const=const)
-
     def generate_inputs(self) -> None:
         input_src_dir_path = path.join(self.src_dir, 'inputs')
         input_header_dir_path = path.join(self.header_dir, 'inputs')


### PR DESCRIPTION
Should have been merged into `tca_suppoer` and then into `master` via #320, however due to a timing issue it was merged into `tca_support` after it had been merged into `master`.

If tests pass, I don't see any reason for this not to be merge-able.