### PR TITLE
Save last checkpoint on SIGTERM

### DIFF
--- a/lmnet/lmnet/utils/signal_handler.py
+++ b/lmnet/lmnet/utils/signal_handler.py
@@ -1,0 +1,34 @@
+
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+import signal
+
+
+class SignalHandler:
+    """ Protect a piece of code from being killed by SIGINT or SIGTERM.
+    It can still be killed by a force kill.
+
+    Both functions will be executed even if a sigterm or sigkill has been received.
+    """
+
+    def __init__(self):
+        self.receivedTermSignal = False
+        signal.signal(signal.SIGTERM, self.handler)
+        signal.signal(signal.SIGINT, self.handler)
+
+    def handler(self, signum, frame):
+        self.lastSignal = signum
+        self.receivedTermSignal = True

--- a/lmnet/tests/lmnet_tests/util_tests/test_signal_handler.py
+++ b/lmnet/tests/lmnet_tests/util_tests/test_signal_handler.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+import signal
+from lmnet.utils.signal_handler import SignalHandler
+
+
+def test_signal_handler():
+    signalhandler = SignalHandler()
+    assert not signalhandler.receivedTermSignal
+
+    signum = 15
+
+    signalhandler.handler(signal.SIGTERM, signum)
+    assert signalhandler.lastSignal == signum
+    assert signalhandler.receivedTermSignal
+
+
+if __name__ == '__main__':
+    test_signal_handler()


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

[ref](https://medium.com/pixboost/save-cash-by-running-kubernetes-services-on-preemptible-vms-in-google-cloud-cca02809ae09)

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
The reason for implementing this feature was to catch SIGTERM signals.

Since we want to use Kubernetes to run training, I found out that saving checkpoints might be useful during graceful shutdowns of Pods on Kubernetes. Since it is sending SIGTERM signals to the main process to not to lose certain checkpoints if the training was terminated.

- create unit test for signal handler
- save checkpoint on sigterm on train.py
- Added signal Handler util class


## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

Can be tested on both `docker` and `kubectl` commands.

### Test on Kubernetes
1. create job
$ kubectl create -f config/mnist-job.yaml
2. Wait until the pod was created and training starts.
$ kubectl -f logs  <pod_id>
3. execute delete job command.
$ kubectl delete job <job_name>

It should show logs same as below.
```
step 603
step 604
step 605
step 606
step 607
step 608
step 609
step 610
step 611
step 612
step 613
step 614
step 615
step 616
step 617
step 618
step 619
step 620
step 621
step 622
Save ckpt. step: 623.
```


### Test on docker
1. Run training
$ ./blueoil.sh train config/{Model name}.yml
2. Wait until the training starts.
3. execute docker stop command.
$ docker stop

It should save the last checkpoint after stop command.

### Test on docker



## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
