### PR TITLE
Improve TFDS Dataset class and iterator

### DIFF
--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -65,10 +65,6 @@ _DATASET_FORMAT_DATASET_MODULE_CLASS = {
         "dataset_module": "delta_mark",
         "dataset_class": "ClassificationBase",
     },
-    "TensorFlow Datasets for Classification": {
-        "dataset_module": "tensorflow_datasets",
-        "dataset_class": "TensorFlowDatasetsClassification",
-    },
     "OpenImagesV4": {
         "dataset_module": "open_images_v4",
         "dataset_class": "OpenImagesV4BoundingBoxBase",

--- a/lmnet/lmnet/datasets/dataset_iterator.py
+++ b/lmnet/lmnet/datasets/dataset_iterator.py
@@ -22,7 +22,6 @@ import queue
 import tensorflow as tf
 from lmnet.datasets.tfds import TFDSBase
 from lmnet.datasets.base import SegmentationBase, ObjectDetectionBase
-from lmnet import data_processor
 
 
 _dataset = None

--- a/lmnet/lmnet/datasets/dataset_iterator.py
+++ b/lmnet/lmnet/datasets/dataset_iterator.py
@@ -19,7 +19,10 @@ import threading
 import numpy as np
 import os
 import queue
+import tensorflow as tf
+from lmnet.datasets.tfds import TFDSBase
 from lmnet.datasets.base import SegmentationBase, ObjectDetectionBase
+from lmnet import data_processor
 
 
 _dataset = None
@@ -197,6 +200,31 @@ class _SimpleDatasetReader:
         return _concat_data(result)
 
 
+class _TFDSReader:
+
+    def __init__(self, dataset):
+        tf_dataset = dataset.tf_dataset.shuffle(1024) \
+                                       .repeat() \
+                                       .batch(dataset.batch_size) \
+                                       .prefetch(tf.data.experimental.AUTOTUNE)
+
+        iterator = tf.data.make_initializable_iterator(tf_dataset)
+
+        self.dataset = dataset
+        self.session = tf.Session()
+        self.session.run(iterator.initializer)
+        self.next_batch = iterator.get_next()
+
+    def read(self):
+        """Return batch size data."""
+        result = []
+        batch = self.session.run(self.next_batch)
+        for image, label in zip(batch['image'], batch['label']):
+            image, label = _apply_augmentations(self.dataset, image, label)
+            result.append((image, label))
+        return _concat_data(result)
+
+
 class DatasetIterator:
 
     available_subsets = ["train", "train_validation_saving", "validation"]
@@ -207,14 +235,18 @@ class DatasetIterator:
         self.enable_prefetch = enable_prefetch
         self.seed = seed
 
-        if self.enable_prefetch:
-            self.prefetch_result_queue = queue.Queue(maxsize=200)
-            self.prefetcher = _MultiProcessDatasetPrefetchThread(self.dataset, self.prefetch_result_queue, seed)
-            self.prefetcher.start()
-            print("ENABLE prefetch")
+        if issubclass(dataset.__class__, TFDSBase):
+            self.enable_prefetch = False
+            self.reader = _TFDSReader(self.dataset)
         else:
-            self.reader = _SimpleDatasetReader(self.dataset, seed)
-            print("DISABLE prefetch")
+            if self.enable_prefetch:
+                self.prefetch_result_queue = queue.Queue(maxsize=200)
+                self.prefetcher = _MultiProcessDatasetPrefetchThread(self.dataset, self.prefetch_result_queue, seed)
+                self.prefetcher.start()
+                print("ENABLE prefetch")
+            else:
+                self.reader = _SimpleDatasetReader(self.dataset, seed)
+                print("DISABLE prefetch")
 
     @property
     def num_per_epoch(self):

--- a/lmnet/lmnet/datasets/tfds.py
+++ b/lmnet/lmnet/datasets/tfds.py
@@ -29,6 +29,8 @@ def _label_to_one_hot(record, depth):
 class TFDSBase(Base):
     """
     Abstract dataset class for loading TensorFlow Datasets.
+    Only images which has 3 channels (RGB) can be loaded for now.
+    TODO(fujiwara): Convert grayscale images into RGB images.
     """
     available_subsets = ["train", "validation"]
     extend_dir = None

--- a/lmnet/lmnet/datasets/tfds.py
+++ b/lmnet/lmnet/datasets/tfds.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
 from lmnet.datasets.base import Base
-from lmnet import data_processor
 
 
 def _label_to_one_hot(record, depth):


### PR DESCRIPTION
## Motivation and Context
Aiming to load larger datasets by using TFDS.

## Description
- Update TFDS dataset class not to load all data on the initialization.
- Add a reader for TFDS dataset class to dataset_iterator.

## How has this been tested?
Run `train.py` with the dataset configuration below:
With downloading:
```python
DATASET_CLASS = TFDSClassification
DATASET.TFDS_NAME = 'cifar10'
DATASET.TFDS_DATA_DIR = 'gs://lmfs-backend-us-west1/shared/tensorflow_datasets'
DATASET.TFDS_DOWNLOAD = True
```

Without downloading:
```python
DATASET_CLASS = TFDSClassification
DATASET.TFDS_NAME = 'cifar10'
DATASET.TFDS_DATA_DIR = 'gs://lmfs-backend-us-west1/shared/tensorflow_datasets'
DATASET.TFDS_DOWNLOAD = False
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
