### PR TITLE
Time measurement reporting tidy-up.

### DIFF
--- a/dlk/tests/test_binary.py
+++ b/dlk/tests/test_binary.py
@@ -89,7 +89,7 @@ class TestBinary(TestCaseDLKBase):
                       join(project_dir, "elf.out"),
                       join(project_dir, "elf.err"),
                       self,
-                      check_stdout_include=['TotalRunTime,']
+                      check_stdout_include=['TotalRunTime ']
                       )
 
         print(f"Binary time-measurement test : passed!")


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
Updated the reporting of timing results.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Popped-up as part of #319.
The previous method of displaying time was slightly confusing, we displayed the same thing time but in a different format.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
From this:
```
root@DE10_NANO:~# ./ref_lm.elf ref_in.npy ref_out.npy
-------------------------------------------------------------
Comparison: Default network test  succeeded!!!
-------------------------------------------------------------
Add,373,186,  sum:0.559ms
BatchNorm,7830,283,  sum:8.113ms
Conv2D TCA,2491,1301,1276,1273,711,418,229,376,680,2450,388,419,393,316,  sum:12.721ms
Convolution,285673,11507,  sum:297.18ms
ExtractImagePatches,14598,4819,943,469,243,63,261,1004,  sum:22.4ms
Max,716,  sum:0.716ms
Memcpy,535,172,74,37,15,20,12,36,142,23,13,20,13,  sum:1.112ms
QTZ_linear_mid_tread_half,45951,  sum:45.951ms
QuantizedConv2D,6741,1991,1641,1480,846,502,352,589,1135,2641,481,502,495,476,  sum:19.872ms
QuantizedConv2D_ApplyScalingFactor,693,  sum:0.693ms
Sync UDMABuf Input,684,380,204,111,68,29,62,107,200,111,40,28,45,28,  sum:2.097ms
Sync UDMABuf Output,378,122,78,52,34,33,28,46,121,38,29,33,29,110,  sum:1.131ms
Tensor convert,3157,164,63,27,16,8,19,46,115,26,10,8,12,8,  sum:3.679ms
TotalInitTime,334912,  sum:334.912ms
TotalRunTime,397301,  sum:397.301ms
func_ConcatOnDepth,415,  sum:0.415ms
kn2row,283915,  sum:283.915ms
kn2row-1x1,11494,  sum:11.494ms
kn2row-buf,9,  sum:0.009ms
matrix_multiplication,171175,11478,  sum:182.653ms
matrix_shift_add_f1,11647,  sum:11.647ms
matrix_shift_add_f2,101050,  sum:101.05ms
matrix_transpose (row_major),18,  sum:0.018ms
pack_input,34346,  sum:34.346ms
---------------------------------------------------
TotalInitTime 334909,  sum:334.909ms
TotalRunTime 397299,  sum:397.299ms
..Convolution 285672,11505,  sum:297.177ms
....kn2row 283914,  sum:283.914ms
......kn2row-buf 7,  sum:0.007ms
......matrix_multiplication 171172,  sum:171.172ms
........matrix_transpose (row_major) 16,  sum:0.016ms
......matrix_shift_add_f1 11645,  sum:11.645ms
......matrix_shift_add_f2 101047,  sum:101.047ms
....kn2row-1x1 11493,  sum:11.493ms
......matrix_multiplication 11475,  sum:11.475ms
..BatchNorm 7827,280,  sum:8.107ms
..QTZ_linear_mid_tread_half 45949,  sum:45.949ms
....pack_input 34343,  sum:34.343ms
..ExtractImagePatches 14595,4816,942,467,241,62,259,1003,  sum:22.385ms
..QuantizedConv2D 6740,1989,1639,1479,845,500,350,587,1133,2639,479,500,493,474,  sum:19.847ms
....Tensor convert 3155,162,61,25,14,6,17,44,113,24,8,6,10,6,  sum:3.651ms
....Sync UDMABuf Input 682,377,202,109,66,27,60,105,198,109,38,26,43,26,  sum:2.068ms
....Conv2D TCA 2489,1298,1274,1271,709,416,227,373,677,2448,386,417,391,314,  sum:12.69ms
....Sync UDMABuf Output 376,120,76,50,32,31,26,44,119,36,27,31,27,108,  sum:1.103ms
..Memcpy 533,170,72,35,14,19,11,35,140,21,11,19,11,  sum:1.091ms
..func_ConcatOnDepth 413,  sum:0.413ms
..QuantizedConv2D_ApplyScalingFactor 689,  sum:0.689ms
..Add 371,184,  sum:0.555ms
..Max 713,  sum:0.713ms
```

To this:
```
root@DE10_NANO:~# ./ref_lm2.elf ref_in.npy ref_out.npy
-------------------------------------------------------------
Comparison: Default network test  succeeded!!!
-------------------------------------------------------------
TotalInitTime 336402,  sum:336.402ms
TotalRunTime 395852,  sum:395.852ms
..Convolution 285992,11560,  sum:297.552ms
....kn2row 284250,  sum:284.25ms
......kn2row-buf 7,  sum:0.007ms
......matrix_multiplication 171303,  sum:171.303ms
........matrix_transpose (row_major) 20,  sum:0.02ms
......matrix_shift_add_f1 11678,  sum:11.678ms
......matrix_shift_add_f2 101217,  sum:101.217ms
....kn2row-1x1 11547,  sum:11.547ms
......matrix_multiplication 11530,  sum:11.53ms
..BatchNorm 6100,275,  sum:6.375ms
..QTZ_linear_mid_tread_half 45960,  sum:45.96ms
....pack_input 34329,  sum:34.329ms
..ExtractImagePatches 14543,4633,942,467,240,62,259,1048,  sum:22.194ms
..QuantizedConv2D 6884,2045,1654,1480,834,501,347,583,1121,2653,482,500,476,474,  sum:20.034ms
....Tensor convert 3261,158,66,27,13,6,16,42,107,26,9,6,8,8,  sum:3.753ms
....Sync UDMABuf Input 675,374,205,109,64,27,61,104,194,113,39,26,39,27,  sum:2.057ms
....Conv2D TCA 2535,1299,1279,1274,703,417,225,373,676,2455,388,417,383,314,  sum:12.738ms
....Sync UDMABuf Output 375,184,76,47,30,31,25,44,118,36,26,31,25,107,  sum:1.155ms
..Memcpy 545,146,75,37,14,17,12,37,143,20,11,23,12,  sum:1.092ms
..func_ConcatOnDepth 414,  sum:0.414ms
..QuantizedConv2D_ApplyScalingFactor 693,  sum:0.693ms
..Add 366,182,  sum:0.548ms
..Max 695,  sum:0.695ms
```

As a note, I decided to keep `Report()` and `DumpTimeTree()` functions separate in case we want to re-format how we dump results later.
## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
