### PR TITLE
call flush method of a writer after the writer wrote summary data

### DIFF
--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -254,6 +254,7 @@ def start_training(config):
                 [metrics_summary_op], feed_dict=metrics_feed_dict,
             )
             train_writer.add_summary(metrics_summary, step + 1)
+            train_writer.flush()
         else:
             sess.run([train_op], feed_dict=feed_dict)
 
@@ -282,6 +283,7 @@ def start_training(config):
                     if train_validation_saving_step % config.SUMMARISE_STEPS == 0:
                         summary, _ = sess.run([summary_op, metrics_update_op], feed_dict=feed_dict)
                         train_val_saving_writer.add_summary(summary, step + 1)
+                        train_val_saving_writer.flush()
                     else:
                         sess.run([metrics_update_op], feed_dict=feed_dict)
 
@@ -293,6 +295,7 @@ def start_training(config):
                     [metrics_summary_op], feed_dict=metrics_feed_dict,
                 )
                 train_val_saving_writer.add_summary(metrics_summary, step + 1)
+                train_val_saving_writer.flush()
 
                 current_train_validation_saving_set_accuracy = sess.run(metrics_ops_dict["accuracy"])
 
@@ -335,6 +338,7 @@ def start_training(config):
                     summary, _ = sess.run([summary_op, metrics_update_op], feed_dict=feed_dict)
                     if rank == 0:
                         val_writer.add_summary(summary, step + 1)
+                        val_writer.flush()
                 else:
                     sess.run([metrics_update_op], feed_dict=feed_dict)
 
@@ -347,6 +351,7 @@ def start_training(config):
             )
             if rank == 0:
                 val_writer.add_summary(metrics_summary, step + 1)
+                val_writer.flush()
 
         progbar.update(step + 1)
     # training loop end.


### PR DESCRIPTION
call flush method of a writer after the writer wrote summary data to flush summary data.

## Motivation and Context

Currently, we cannot see the latest metrics on tensorboard, because the latest metrics data is in a buffer, not written to a file.

## Description

Call `flush` method after every calling of `write` method of FileWriter object.

## How has this been tested?

Execute `lmnet/executor/train.py` with a config file, check the training result on tensorboard.
You can check the latest validation accuracy immediately after a validation session run.

## Screenshots (if appropriate):

None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.