### PR TITLE
Show only rank 0 progbar

### DIFF
--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -213,7 +213,8 @@ def start_training(config):
         max_steps = config.MAX_STEPS
 
     progbar = Progbar(max_steps)
-    progbar.update(last_step)
+    if rank == 0:
+        progbar.update(last_step)
     for step in range(last_step, max_steps):
         if config.IS_DISTRIBUTION:
             # scatter dataset
@@ -348,7 +349,8 @@ def start_training(config):
             if rank == 0:
                 val_writer.add_summary(metrics_summary, step + 1)
 
-        progbar.update(step + 1)
+        if rank == 0:
+            progbar.update(step + 1)
     # training loop end.
     print("Done")
 


### PR DESCRIPTION
We have a hidden feature, distributed training on Horovod. Current behavior of `train.py` is cluttered by random multiple progress bars, as Horovod utilize multiple processes for distributed training.

This pull request fix the problem by checking the `rank` of the process. (Here, concept of the `rank` comes from MPI.)

## Motivation and Context

Wrote as above.

## Description

add some `if` conditions that checks whether the rank is 0, to show progress of rank 0 process only.

## How has this been tested?

execute distributed training, see the console.

## Screenshots (if appropriate):

None

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
