### PR TITLE
use tf.cast instead of tf.to_int32, etc

### DIFF
--- a/lmnet/lmnet/metrics/mean_average_precision.py
+++ b/lmnet/lmnet/metrics/mean_average_precision.py
@@ -86,8 +86,8 @@ def _streaming_tp_fp_array(
                                        [num_gt_boxes, tp, fp, scores]):
         tp = tf.cast(tp, tf.bool)
         fp = tf.cast(fp, tf.bool)
-        scores = tf.to_float(scores)
-        num_gt_boxes = tf.to_int64(num_gt_boxes)
+        scores = tf.cast(scores, tf.float32)
+        num_gt_boxes = tf.cast(num_gt_boxes, tf.int64)
 
         # Reshape TP and FP tensors and clean away 0 class values.
         tp = tf.reshape(tp, [-1])

--- a/lmnet/lmnet/metrics/metrics.py
+++ b/lmnet/lmnet/metrics/metrics.py
@@ -29,13 +29,13 @@ def tp_tn_fp_fn_for_each(output, labels, threshold=0.5):
         threshold: python float
     """
     predicted = tf.greater_equal(output, threshold)
-    gt_positive = tf.reduce_sum(tf.to_int32(labels), 0, keep_dims=True)
-    gt_negative = tf.reduce_sum(tf.to_int32(tf.logical_not(labels)), 0, keep_dims=True)
+    gt_positive = tf.reduce_sum(tf.cast(labels, tf.int32), 0, keep_dims=True)
+    gt_negative = tf.reduce_sum(tf.cast(tf.logical_not(labels), tf.int32), 0, keep_dims=True)
     true_positive = tf.logical_and(predicted, labels)
-    true_positive = tf.reduce_sum(tf.to_int32(true_positive), 0, keep_dims=True)
+    true_positive = tf.reduce_sum(tf.cast(true_positive, tf.int32), 0, keep_dims=True)
 
     true_negative = tf.logical_and(tf.logical_not(predicted), tf.logical_not(labels))
-    true_negative = tf.reduce_sum(tf.to_int32(true_negative), 0, keep_dims=True)
+    true_negative = tf.reduce_sum(tf.cast(true_negative, tf.int32), 0, keep_dims=True)
     false_negative = gt_positive - true_positive
     false_positive = gt_negative - true_negative
 
@@ -52,14 +52,14 @@ def tp_tn_fp_fn(output, labels, threshold=0.5):
     """
     predicted = tf.greater_equal(output, threshold)
 
-    gt_positive = tf.reduce_sum(tf.to_int32(labels))
-    gt_negative = tf.reduce_sum(tf.to_int32(tf.logical_not(labels)))
+    gt_positive = tf.reduce_sum(tf.cast(labels, tf.int32))
+    gt_negative = tf.reduce_sum(tf.cast(tf.logical_not(labels), tf.int32))
 
     true_positive = tf.logical_and(predicted, labels)
-    true_positive = tf.reduce_sum(tf.to_int32(true_positive))
+    true_positive = tf.reduce_sum(tf.cast(true_positive, tf.int32))
 
     true_negative = tf.logical_and(tf.logical_not(predicted), tf.logical_not(labels))
-    true_negative = tf.reduce_sum(tf.to_int32(true_negative))
+    true_negative = tf.reduce_sum(tf.cast(true_negative, tf.int32))
 
     false_negative = gt_positive - true_positive
 

--- a/lmnet/lmnet/networks/classification/base.py
+++ b/lmnet/lmnet/networks/classification/base.py
@@ -97,7 +97,7 @@ class Base(BaseNetwork):
         """
 
         with tf.name_scope("loss"):
-            labels = tf.to_float(labels)
+            labels = tf.cast(labels, tf.float32)
             cross_entropy = -tf.reduce_sum(
                 labels * tf.log(tf.clip_by_value(softmax, 1e-10, 1.0)),
                 axis=[1]
@@ -137,7 +137,7 @@ class Base(BaseNetwork):
 
         for i, class_name in enumerate(self.classes):
             class_heatmap = heatmap[:, :, :, i]
-            indices = tf.to_int32(tf.round(class_heatmap * 255))
+            indices = tf.cast(tf.round(class_heatmap * 255), tf.int32)
             color_map = cm.jet
             # Init color map for useing color lookup table(_lut).
             color_map._init()
@@ -192,7 +192,7 @@ class Base(BaseNetwork):
            labels: onehot labels tensor. shape is (batch_num, num_classes)
         """
         with tf.name_scope("metrics_calc"):
-            labels = tf.to_float(labels)
+            labels = tf.cast(labels, tf.float32)
 
             if self.is_debug:
                 labels = tf.Print(labels, [tf.shape(labels), tf.argmax(labels, 1)], message="labels:", summarize=200)

--- a/lmnet/lmnet/networks/classification/resnet.py
+++ b/lmnet/lmnet/networks/classification/resnet.py
@@ -166,7 +166,7 @@ class Resnet(Base):
            output: softmaxed tensor from base. shape is (batch_num, num_classes)
            labels: onehot labels tensor. shape is (batch_num, num_classes)
         """
-        labels = tf.to_float(labels)
+        labels = tf.cast(labels, tf.float32)
 
         if self.is_debug:
             labels = tf.Print(labels, [tf.shape(labels), tf.argmax(labels, 1)], message="labels:", summarize=200)

--- a/lmnet/lmnet/networks/lmnet_multi.py
+++ b/lmnet/lmnet/networks/lmnet_multi.py
@@ -64,7 +64,7 @@ class LmnetMulti:
         """
 
         with tf.name_scope("loss"):
-            labels = tf.to_float(labels)
+            labels = tf.cast(labels, tf.float32)
             if self.is_debug:
                 labels = tf.Print(labels, [tf.shape(labels), tf.argmax(labels, 1)], message="labels:", summarize=200)
                 output = tf.Print(output, [tf.shape(output), tf.argmax(output, 1)], message="output:", summarize=200)

--- a/lmnet/lmnet/networks/object_detection/yolo_v2.py
+++ b/lmnet/lmnet/networks/object_detection/yolo_v2.py
@@ -104,7 +104,9 @@ class YoloV2(BaseNetwork):
 
             # TODO(wakisaka): Be enable to change `32`. it depends on pooling times.
             # Number of cell is the spatial dimension of the final convolutional features.
-            self.num_cell = tf.tuple([tf.cast((self.image_size[0] / 32), tf.int32), tf.cast((self.image_size[1] / 32), tf.int32)])
+            image_size0 = self.image_size[0] / 32
+            image_size1 = self.image_size[1] / 32
+            self.num_cell = tf.tuple([tf.cast(image_size0, tf.int32), tf.cast(image_size1, tf.int32)])
         else:
             self.num_cell = self.image_size[0] // 32, self.image_size[1] // 32
 

--- a/lmnet/lmnet/networks/object_detection/yolo_v2.py
+++ b/lmnet/lmnet/networks/object_detection/yolo_v2.py
@@ -102,9 +102,9 @@ class YoloV2(BaseNetwork):
                 tf.constant(self.image_size[0], dtype=tf.int32), tf.constant(self.image_size[1], dtype=tf.int32)
             ])
 
-            # TODO(wakisaka): Be enable to cnahge `32`. it depends on pooling times.
+            # TODO(wakisaka): Be enable to change `32`. it depends on pooling times.
             # Number of cell is the spatial dimension of the final convolutional features.
-            self.num_cell = tf.tuple([tf.to_int32(self.image_size[0] / 32), tf.to_int32(self.image_size[1] / 32)])
+            self.num_cell = tf.tuple([tf.cast((self.image_size[0] / 32), tf.int32), tf.cast((self.image_size[1] / 32), tf.int32)])
         else:
             self.num_cell = self.image_size[0] // 32, self.image_size[1] // 32
 
@@ -175,7 +175,7 @@ class YoloV2(BaseNetwork):
             tf.summary.scalar("score_threshold", self.score_threshold)
             tf.summary.scalar("nms_iou_threshold", self.nms_iou_threshold)
             tf.summary.scalar("nms_max_output_size", self.nms_max_output_size)
-            tf.summary.scalar("nms_per_class", tf.to_int32(self.nms_per_class))
+            tf.summary.scalar("nms_per_class", tf.cast(self.nms_per_class, tf.int32))
 
         if self.change_base_output:
             predict_classes, predict_confidence, predict_boxes = self._split_predictions(output)
@@ -313,7 +313,7 @@ class YoloV2(BaseNetwork):
             gt_boxes :3D tensor [batch_size, max_num_boxes, 5(x, y, w, h, class_id)]
         """
         axis = 2
-        gt_boxes = tf.to_float(gt_boxes)
+        gt_boxes = tf.cast(gt_boxes, tf.float32)
         gt_boxes_without_label = gt_boxes[:, :, :4]
         gt_boxes_only_label = tf.reshape(gt_boxes[:, :, 4], [self.batch_size, -1, 1])
         gt_boxes_without_label = format_XYWH_to_CXCYWH(gt_boxes_without_label, axis=axis)
@@ -389,11 +389,11 @@ class YoloV2(BaseNetwork):
             resized_boxes: 5D Tensor,
                            shape is [batch_size, num_cell, num_cell, boxes_per_cell, 4(center_x, center_y, w, h)].
         """
-        image_size_h, image_size_w = tf.to_float(self.image_size[0]), tf.to_float(self.image_size[1])
-        num_cell_y, num_cell_x = tf.to_float(self.num_cell[0]), tf.to_float(self.num_cell[1])
+        image_size_h, image_size_w = tf.cast(self.image_size[0], tf.float32), tf.cast(self.image_size[1], tf.float32)
+        num_cell_y, num_cell_x = tf.cast(self.num_cell[0], tf.float32), tf.cast(self.num_cell[1], tf.float32)
 
         offset_x, offset_y, offset_w, offset_h = self.offset_boxes()
-        offset_x, offset_y = tf.to_float(offset_x), tf.to_float(offset_y)
+        offset_x, offset_y = tf.cast(offset_x, tf.float32), tf.cast(offset_y, tf.float32)
 
         resized_boxes = boxes / [
             image_size_w,
@@ -426,11 +426,11 @@ class YoloV2(BaseNetwork):
             resized_boxes: 5D Tensor,
                            shape is [batch_size, num_cell, num_cell, boxes_per_cell, 4(center_x, center_y, w, h)].
         """
-        image_size_h, image_size_w = tf.to_float(self.image_size[0]), tf.to_float(self.image_size[1])
-        num_cell_y, num_cell_x = tf.to_float(self.num_cell[0]), tf.to_float(self.num_cell[1])
+        image_size_h, image_size_w = tf.cast(self.image_size[0], tf.float32), tf.cast(self.image_size[1], tf.float32)
+        num_cell_y, num_cell_x = tf.cast(self.num_cell[0], tf.float32), tf.cast(self.num_cell[1], tf.float32)
 
         offset_x, offset_y, offset_w, offset_h = self.offset_boxes()
-        offset_x, offset_y = tf.to_float(offset_x), tf.to_float(offset_y)
+        offset_x, offset_y = tf.cast(offset_x, tf.float32), tf.cast(offset_y, tf.float32)
 
         resized_predict_boxes = tf.stack([
             (predict_boxes[:, :, :, :, 0] + offset_x) / num_cell_x,
@@ -1384,8 +1384,8 @@ class YoloV2Loss:
                 [tf.float32, tf.float32, tf.int64, tf.int64]
             )
 
-        object_maskes = tf.to_float(object_maskes)
-        coordinate_maskes = tf.to_float(coordinate_maskes)
+        object_maskes = tf.cast(object_maskes, tf.float32)
+        coordinate_maskes = tf.cast(coordinate_maskes, tf.float32)
         return cell_gt_boxes, truth_confidence, object_maskes, coordinate_maskes
 
     def _weight_decay_loss(self):
@@ -1433,7 +1433,7 @@ class YoloV2Loss:
             # iou_mask: [batch_size, num_cell, num_cell, boxes_per_cell, 1]
             iou_mask = best_iou > self.loss_iou_threshold
             iou_mask = tf.expand_dims(iou_mask, 4)
-            iou_mask = tf.to_float(iou_mask)
+            iou_mask = tf.cast(iou_mask, tf.float32)
 
             if self.is_debug:
                 iou_mask = tf.Print(
@@ -1451,7 +1451,7 @@ class YoloV2Loss:
                                                  predict_classes, predict_confidence)
 
             # for class loss
-            truth_classes = tf.to_int32(cell_gt_boxes[:, :, :, :, 4])
+            truth_classes = tf.cast(cell_gt_boxes[:, :, :, :, 4], tf.int32)
             truth_classes = tf.one_hot(truth_classes, self.num_classes)
 
             cell_gt_boxes = cell_gt_boxes[:, :, :, :, :4]
@@ -1553,10 +1553,10 @@ def summary_boxes(tag, images, boxes, image_size, max_outputs=3, data_format="NH
             images = tf.transpose(images, [0, 2, 3, 1])
 
         boxes = tf.stack([
-            boxes[:, :, 0] / tf.to_float(image_size[0]),
-            boxes[:, :, 1] / tf.to_float(image_size[1]),
-            boxes[:, :, 2] / tf.to_float(image_size[0]),
-            boxes[:, :, 3] / tf.to_float(image_size[1]),
+            boxes[:, :, 0] / tf.cast(image_size[0], tf.float32),
+            boxes[:, :, 1] / tf.cast(image_size[1], tf.float32),
+            boxes[:, :, 2] / tf.cast(image_size[0], tf.float32),
+            boxes[:, :, 3] / tf.cast(image_size[1], tf.float32),
         ], axis=2)
 
         bb_images = tf.image.draw_bounding_boxes(images, boxes)

--- a/lmnet/lmnet/networks/segmentation/base.py
+++ b/lmnet/lmnet/networks/segmentation/base.py
@@ -76,7 +76,7 @@ class Base(BaseNetwork):
 
     def _summary_labels(self, labels):
 
-        tf.summary.image("labels", tf.to_float(tf.expand_dims(labels, axis=3)))
+        tf.summary.image("labels", tf.cast(tf.expand_dims(labels, axis=3), tf.float32))
 
         labels = self._color_labels(labels, name="labels_color")
 
@@ -172,9 +172,9 @@ class SegnetBase(Base):
         with tf.name_scope("loss"):
             # calculate loss weights for each class.
             loss_weight = []
-            all_size = tf.to_float(tf.reduce_prod(tf.shape(labels)))
+            all_size = tf.cast(tf.reduce_prod(tf.shape(labels)), tf.float32)
             for class_index in range(self.num_classes):
-                num_label = tf.reduce_sum(tf.to_float(tf.equal(labels, class_index)))
+                num_label = tf.reduce_sum(tf.cast(tf.equal(labels, class_index), tf.float32))
                 weight = (all_size - num_label) / all_size
                 loss_weight.append(weight)
 

--- a/lmnet/lmnet/quantizations/ternary.py
+++ b/lmnet/lmnet/quantizations/ternary.py
@@ -120,13 +120,13 @@ def twn_weight_quantizer(threshold=0.7, dtype=tf.float32):
         Returns:
             quantized(tf.Variable): The quantized weights.
         """
-        ternary_threshold = tf.reduce_sum(tf.abs(weights)) * threshold / tf.to_float(tf.size(weights))
+        ternary_threshold = tf.reduce_sum(tf.abs(weights)) * threshold / tf.cast(tf.size(weights), tf.float32)
         mask_positive = (weights > ternary_threshold)
         mask_negative = (weights < -ternary_threshold)
         mask_p_or_n = mask_positive | mask_negative
 
         p_or_n_weights = tf.where(mask_p_or_n, weights, tf.zeros_like(weights))
-        scaling_factor = tf.reduce_sum(tf.abs(p_or_n_weights)) / tf.reduce_sum(tf.to_float(mask_p_or_n))
+        scaling_factor = tf.reduce_sum(tf.abs(p_or_n_weights)) / tf.reduce_sum(tf.cast(mask_p_or_n, tf.float32))
 
         positive_weights = scaling_factor * tf.where(mask_positive, tf.ones_like(weights), tf.zeros_like(weights))
         negative_weights = - scaling_factor * tf.where(mask_negative, tf.ones_like(weights), tf.zeros_like(weights))


### PR DESCRIPTION
use tf.cast instead of tf.to_int32 and tf.to_float, because these functions are deprecated.

## Motivation and Context

We should not use deprecated functions/methods. This refactoring PR reduce the number of using deprecated functions.

## Description

Just rewrote some function calls.

## How has this been tested?

unit test.

## Screenshots (if appropriate):

None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
