### PR TITLE
Delete absolute mode path from train executor

### DIFF
--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -26,6 +26,7 @@ from lmnet import environment
 from lmnet.datasets.base import ObjectDetectionBase
 from lmnet.datasets.dataset_iterator import DatasetIterator
 from lmnet.datasets.tfds import TFDSClassification, TFDSObjectDetection
+from lmnet.common import Tasks
 
 
 def _save_checkpoint(saver, sess, global_step, step):
@@ -85,7 +86,7 @@ def start_training(config):
 
     graph = tf.Graph()
     with graph.as_default():
-        if ModelClass.__module__.startswith("lmnet.networks.object_detection"):
+        if config.TASK == Tasks.OBJECT_DETECTION:
             model = ModelClass(
                 classes=train_dataset.classes,
                 num_max_boxes=train_dataset.num_max_boxes,
@@ -105,7 +106,7 @@ def start_training(config):
         images_placeholder, labels_placeholder = model.placeholders()
 
         output = model.inference(images_placeholder, is_training_placeholder)
-        if ModelClass.__module__.startswith("lmnet.networks.object_detection"):
+        if config.TASK == Tasks.OBJECT_DETECTION:
             loss = model.loss(output, labels_placeholder, global_step)
         else:
             loss = model.loss(output, labels_placeholder)

--- a/lmnet/tests/lmnet_tests/networks_tests/classification_test/test_darknet.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/classification_test/test_darknet.py
@@ -22,6 +22,7 @@ from lmnet.datasets.image_folder import ImageFolderBase
 from lmnet.networks.classification.darknet import Darknet
 from lmnet.utils.executor import prepare_dirs
 from lmnet.pre_processor import Resize
+from lmnet.common import Tasks
 from executor.train import start_training
 
 
@@ -50,6 +51,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.CLASSIFICATION
 
     # network model config
     config.NETWORK = EasyDict()

--- a/lmnet/tests/lmnet_tests/networks_tests/classification_test/test_lmnet_quantize.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/classification_test/test_lmnet_quantize.py
@@ -26,6 +26,7 @@ from lmnet.quantizations import (
     binary_mean_scaling_quantizer,
     linear_mid_tread_half_quantizer,
 )
+from lmnet.common import Tasks
 from executor.train import start_training
 
 # Apply reset_default_graph() in conftest.py to all tests in this file.
@@ -53,6 +54,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.CLASSIFICATION
 
     # network model config
     config.NETWORK = EasyDict()

--- a/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v1.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v1.py
@@ -23,6 +23,7 @@ from lmnet.datasets.lm_things_on_a_table import LmThingsOnATable
 from lmnet.networks.object_detection.yolo_v1 import YoloV1
 from lmnet.utils.executor import prepare_dirs
 from lmnet.pre_processor import ResizeWithGtBoxes
+from lmnet.common import Tasks
 from executor.train import start_training
 
 # Apply reset_default_graph() in conftest.py to all tests in this file.
@@ -279,6 +280,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.OBJECT_DETECTION
 
     # network model config
     config.NETWORK = EasyDict()

--- a/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v2.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v2.py
@@ -30,6 +30,7 @@ from lmnet.post_processor import (
     ExcludeLowScoreBox,
     NMS,
 )
+from lmnet.common import Tasks
 
 # Apply reset_default_graph() in conftest.py to all tests in this file.
 # Set test environment
@@ -713,6 +714,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.OBJECT_DETECTION
 
     # network model config
     config.NETWORK = EasyDict()

--- a/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v2_quantize.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/object_detection_tests/test_yolo_v2_quantize.py
@@ -26,6 +26,7 @@ from lmnet.quantizations import (
     binary_channel_wise_mean_scaling_quantizer,
     linear_mid_tread_half_quantizer,
 )
+from lmnet.common import Tasks
 from executor.train import start_training
 
 
@@ -51,6 +52,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.OBJECT_DETECTION
 
     # network model config
     config.NETWORK = EasyDict()

--- a/lmnet/tests/lmnet_tests/networks_tests/segmentation_tests/test_lm_bisenet.py
+++ b/lmnet/tests/lmnet_tests/networks_tests/segmentation_tests/test_lm_bisenet.py
@@ -30,6 +30,7 @@ from lmnet.post_processor import (
 )
 from lmnet.pre_processor import Resize
 from lmnet.utils.executor import prepare_dirs
+from lmnet.common import Tasks
 
 
 # Apply reset_default_graph() and set_test_environment() in conftest.py to all tests in this file.
@@ -56,6 +57,7 @@ def test_training():
     config.KEEP_CHECKPOINT_MAX = 5
     config.SUMMARISE_STEPS = 1
     config.IS_PRETRAIN = False
+    config.TASK = Tasks.SEMANTIC_SEGMENTATION
 
     # network model config
     config.NETWORK = EasyDict()


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
If you create some new object detection class outside of `lmnet.networks.object_detection`, train executor doesn't work.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Changed to use task type (`Tasks.OBJECT_DETECTION`) from class path

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
only unit test

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
