### PR TITLE
update TF version to 1.14.0, Horovod version to 0.18.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -135,6 +135,10 @@ RUN ldconfig /usr/local/cuda-10.0/targets/x86_64-linux/lib/stubs && \
     pip install -r /tmp/requirements/dist.requirements.txt && \
     ldconfig
 
+# change default back to gcc-5/g++-5
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
+
 # Configure OpenMPI to run good defaults:
 #   --bind-to none --map-by slot --mca btl_tcp_if_exclude lo,docker0 --mca btl_vader_single_copy_mechanism none
 RUN echo "hwloc_base_binding_policy = none" >> /usr/local/etc/openmpi-mca-params.conf && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,10 @@ RUN mkdir /tmp/openmpi && \
 RUN apt-get install -y --no-install-recommends openssh-client openssh-server && \
     mkdir -p /var/run/sshd
 
+# set g++-4.9 as default to build Horovod with TensorFlow 1.14.0.
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 10
+
 # Set env to install horovod with nccl and tensorflow option
 ENV HOROVOD_GPU_ALLREDUCE NCCL
 ENV HOROVOD_WITH_TENSORFLOW 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # Install dependencies for Pillow, Scipy and matplotlib for display, and requirements for pyenv and pyenv virtualenv installation
+# g++-4.9 is required to build Horovod with TensorFlow 1.14.0. For more detail, see https://github.com/horovod/horovod/issues/1232
 RUN apt-get update && apt-get install -y \
     python3-pil \
     libjpeg8-dev \
@@ -47,6 +48,7 @@ RUN apt-get update && apt-get install -y \
     libncursesw5-dev \
     xz-utils \
     tk-dev \
+    g++-4.9 \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,10 +120,6 @@ RUN mkdir /tmp/openmpi && \
 RUN apt-get install -y --no-install-recommends openssh-client openssh-server && \
     mkdir -p /var/run/sshd
 
-# set g++-4.9 as default to build Horovod with TensorFlow 1.14.0.
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 10
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 10
-
 # Set env to install horovod with nccl and tensorflow option
 ENV HOROVOD_GPU_ALLREDUCE NCCL
 ENV HOROVOD_WITH_TENSORFLOW 1
@@ -134,10 +130,6 @@ ENV CUDA_HOME /usr/local/cuda-10.0
 RUN ldconfig /usr/local/cuda-10.0/targets/x86_64-linux/lib/stubs && \
     pip install -r /tmp/requirements/dist.requirements.txt && \
     ldconfig
-
-# change default back to gcc-5/g++-5
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
 
 # Configure OpenMPI to run good defaults:
 #   --bind-to none --map-by slot --mca btl_tcp_if_exclude lo,docker0 --mca btl_vader_single_copy_mechanism none

--- a/lmnet/cpu.requirements.txt
+++ b/lmnet/cpu.requirements.txt
@@ -1,2 +1,3 @@
 -r dev.requirements.txt
-tensorflow==1.13.1
+tensorflow==1.14.0
+gast==0.2.2

--- a/lmnet/dist.requirements.txt
+++ b/lmnet/dist.requirements.txt
@@ -1,3 +1,3 @@
 # for distributed training
-horovod==0.16.4
+horovod==0.18.1
 mpi4py==3.0.2

--- a/lmnet/dockerfiles/multi-gpu.Dockerfile
+++ b/lmnet/dockerfiles/multi-gpu.Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     git \
     wget \
+    g++-4.9 \
     ca-certificates \
     libjpeg-dev \
     libpng-dev

--- a/lmnet/gpu.requirements.txt
+++ b/lmnet/gpu.requirements.txt
@@ -1,2 +1,2 @@
 -r dev.requirements.txt
-tensorflow-gpu==1.13.1
+tensorflow-gpu==1.14.0

--- a/lmnet/requirements.txt
+++ b/lmnet/requirements.txt
@@ -1,7 +1,7 @@
 click==6.7
 easydict==1.6
 matplotlib==2.2.2
-numpy==1.14.0
+numpy==1.15.0
 pandas==0.19.2
 Pillow==6.0.0
 pytablewriter==0.35


### PR DESCRIPTION
## Motivation and Context

TensorFlow 1.14.0 warn more deprecated functions than 0.13.1. We should fix such warnings before upgrading to TF 2.0.

## Description
- upgrade TF version to 1.14.0
- A new dependency `gast==0.2.2` is necessary for TF 1.14.0. (recently released `gast` `0.3.x` is not compatible with `0.2.x`, that cause some unreasonable warning messages.)
- Horovod is also updated to the latest version, since TF 1.14.0 seems sometimes not compatible with Horovod 0.16.4. (For more detail, see https://github.com/horovod/horovod/issues/1232)
 
## How has this been tested?

- unit test
- by running some training scripts

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [x] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
