### PR TITLE
Fix to save image in png format correctly in lmnet/executor/export.py

### DIFF
--- a/lmnet/executor/export.py
+++ b/lmnet/executor/export.py
@@ -51,7 +51,8 @@ def _pre_process(raw_image, pre_processor, data_format):
 
 def _save_npy(image_path, output_dir, image, raw_image, all_outputs, image_size):
     shutil.copy(image_path, os.path.join(output_dir))
-    shutil.copy(image_path, os.path.join(output_dir, "raw_image.png"))
+    tmp_image = PIL.Image.open(image_path)
+    tmp_image.save(os.path.join(output_dir, "raw_image.png"))
     np.save(os.path.join(output_dir, "raw_image.npy"), raw_image)
 
     np.save(os.path.join(output_dir, "preprocessed_image.npy"), image)


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
In `lmnet/executor/export.py`, copy image name as `raw_image.png` even though source image `image_path` is not png format.  I I fixed to save`raw_image.png` in png format correctly in any case.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
