### PR TITLE
Fix depth calculation for concat_on_depth

### DIFF
--- a/dlk/python/dlk/core/view.py
+++ b/dlk/python/dlk/core/view.py
@@ -647,14 +647,11 @@ class View(object):
 
             inputs_string = self.inputs_to_string(concat_input)
 
-            depth_list = ', '.join(map(lambda x: str(x.channel), concat_input.values()))
-
             return self.format_string(
                 f"""
                 const TensorView<{op.dtype.cpptype()}, MemoryLayout::{op.dimension}> {input_list_name}[] = \
                 {{ {inputs_string} }};
-                T_UINT {depth_list_name}[] = {{ {depth_list} }};
-                func_ConcatOnDepth({input_list_name}, {depth_list_name}, {number_of_inputs}, {op.name});
+                func_ConcatOnDepth({input_list_name}, {number_of_inputs}, {op.name});
                 """
             )
         elif self.op.op_type == 'Maximum':

--- a/dlk/python/dlk/templates/include/func/concat_on_depth.h
+++ b/dlk/python/dlk/templates/include/func/concat_on_depth.h
@@ -21,20 +21,15 @@ limitations under the License.
 
 template<class T>
 void func_ConcatOnDepth(const TensorView<T, MemoryLayout::NHWC> inputs[],
-    T_UINT *depths, T_UINT n_inputs,
-    const TensorView<T, MemoryLayout::NHWC>& output) {
+    T_UINT n_inputs, const TensorView<T, MemoryLayout::NHWC>& output) {
   Measurement::Start("func_ConcatOnDepth");
   const auto shape = output.get_shape();
   T_UINT out_height = shape[1];
   T_UINT out_width = shape[2];
 
-  T_UINT output_index = 0;
-  T_UINT input_index[32] = {0};
-
-  if (!std::is_same<T, typename Base<T>::type>::value) {
-    // quantized and packed inputs
-    for(T_UINT i = 0; i < n_inputs; i++)
-      depths[i] /= 32;
+  T_UINT depths[32];
+  for (T_UINT n = 0; n < n_inputs; ++n) {
+    depths[n] = inputs[n].get_shape()[3];
   }
 
   T_UINT index = 0;
@@ -52,21 +47,16 @@ void func_ConcatOnDepth(const TensorView<T, MemoryLayout::NHWC> inputs[],
 
 template<class T>
 void func_ConcatOnDepth(const TensorView<T, MemoryLayout::HWChBCl> inputs[],
-    T_UINT *depths, T_UINT n_inputs,
-    const TensorView<T, MemoryLayout::HWChBCl>& output) {
+    T_UINT n_inputs, const TensorView<T, MemoryLayout::HWChBCl>& output) {
   Measurement::Start("func_ConcatOnDepth");
   const auto shape = output.get_shape();
   T_UINT out_height = shape[0];
   T_UINT out_width = shape[1];
   T_UINT bits = shape[3];
 
-  T_UINT output_index = 0;
-  T_UINT input_index[32] = {0};
-
-  if (!std::is_same<T, typename Base<T>::type>::value) {
-    // quantized and packed inputs
-    for(T_UINT i = 0; i < n_inputs; i++)
-      depths[i] /= 32;
+  T_UINT depths[32];
+  for (T_UINT n = 0; n < n_inputs; ++n) {
+    depths[n] = inputs[n].get_shape()[3];
   }
 
   T_UINT index = 0;
@@ -86,21 +76,16 @@ void func_ConcatOnDepth(const TensorView<T, MemoryLayout::HWChBCl> inputs[],
 
 template<class T>
 void func_ConcatOnDepth(const TensorView<T, MemoryLayout::ChHWBCl> inputs[],
-    T_UINT *depths, T_UINT n_inputs,
-    const TensorView<T, MemoryLayout::ChHWBCl>& output) {
+    T_UINT n_inputs, const TensorView<T, MemoryLayout::ChHWBCl>& output) {
   Measurement::Start("func_ConcatOnDepth");
   const auto shape = output.get_shape();
   T_UINT out_height = shape[1];
   T_UINT out_width = shape[2];
   T_UINT bits = shape[3];
 
-  T_UINT output_index = 0;
-  T_UINT input_index[32] = {0};
-
-  if (!std::is_same<T, typename Base<T>::type>::value) {
-    // quantized and packed inputs
-    for(T_UINT i = 0; i < n_inputs; i++)
-      depths[i] /= 32;
+  T_UINT depths[32];
+  for (T_UINT n = 0; n < n_inputs; ++n) {
+    depths[n] = inputs[n].get_shape()[3];
   }
 
   T_UINT index = 0;

--- a/dlk/python/dlk/templates/include/func/concat_on_depth.h
+++ b/dlk/python/dlk/templates/include/func/concat_on_depth.h
@@ -56,7 +56,7 @@ void func_ConcatOnDepth(const TensorView<T, MemoryLayout::HWChBCl> inputs[],
 
   T_UINT depths[32];
   for (T_UINT n = 0; n < n_inputs; ++n) {
-    depths[n] = inputs[n].get_shape()[3];
+    depths[n] = inputs[n].get_shape()[2];
   }
 
   T_UINT index = 0;
@@ -85,7 +85,7 @@ void func_ConcatOnDepth(const TensorView<T, MemoryLayout::ChHWBCl> inputs[],
 
   T_UINT depths[32];
   for (T_UINT n = 0; n < n_inputs; ++n) {
-    depths[n] = inputs[n].get_shape()[3];
+    depths[n] = inputs[n].get_shape()[0];
   }
 
   T_UINT index = 0;


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

concat_on_depth was broken for quantized types...

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

This PR fix depth calculation for concat_on_depth.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

- Fix depth calculation
- Remove unnecessary parameter
- Remove unused variables

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
