### PR TITLE
update pytest version to 5.2.0

### DIFF
--- a/lmnet/test.requirements.txt
+++ b/lmnet/test.requirements.txt
@@ -1,3 +1,3 @@
 tox==2.9.1
 flake8==3.5.0
-pytest==3.3.2
+pytest==5.2.0


### PR DESCRIPTION
## Motivation and Context

Recently, our automated tests are failed with an error message below:

```
TypeError: attrib() got an unexpected keyword argument 'convert'
```
@hadusam tought me that the version incompatibility between `attrs` and `pytest` causes this problem.

There're two solutions we can choose, 1st solution is downgrading of `attrs`, 2nd solution is upgrading `pytest`. I chose later.

see also: https://github.com/pytest-dev/pytest/issues/3280

## Description

just updated pytest version

## How has this been tested?

unit test

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
