### PR TITLE
Fix DLK code generation test cases

### DIFF
--- a/dlk/tests/test_code_generation.py
+++ b/dlk/tests/test_code_generation.py
@@ -34,362 +34,72 @@ from tstconf import CURRENT_TEST_LEVEL
 from tstutils import updated_dict, run_and_check, TEST_LEVEL_FUTURE_TARGET, FPGA_HOST
 
 
-def dict_codegen_classification_x86() -> dict:
-    """Test parameters for testing code generation for classification on CPU (float only)"""
-    return {'model_path': os.path.join('examples', 'classification', 'lmnet_quantize_cifar10'),
-            'expected_output_set_name': 'cat.jpg',
+def dict_codegen_classification(cpu_name) -> dict:
+    """Test parameters for testing code generation for classification on CPU (lmnet_quantize)"""
+    return {'model_path': os.path.join('examples', 'classification', 'lmnet_quantize_cifar10_space_to_depth'),
+            'expected_output_set_name': '1000_dog.png',
             'prefix': 'cls',
             'input_name': '000_images_placeholder:0.npy',
             'output_npy_name': '133_output:0.npy',
-            'hard_quantize': False,
-            'threshold_skipping': False,
-            'use_avx': False
+            'cpu_name': cpu_name,
             }
 
 
-def dict_codegen_resnet_classification_x86() -> dict:
+def dict_codegen_classification_resnet(cpu_name) -> dict:
     """Test parameters for testing code generation for classification on CPU (float only)"""
     return {'model_path': os.path.join('examples', 'classification', 'resnet_quantize_cifar10'),
             'expected_output_set_name': '9984_horse.png',
-            'prefix': 'resnet_cls',
+            'prefix': 'cls_resnet',
             'input_name': '000_images_placeholder:0.npy',
             'output_npy_name': '368_output:0.npy',
-            'hard_quantize': False,
-            'threshold_skipping': False,
-            'use_avx': False
+            'cpu_name': cpu_name,
             }
 
 
-def dict_codegen_group_conv_classification_x86() -> dict:
-    """Test parameters for testing code generation for classification on CPU"""
-    return {'model_path': os.path.join('examples', 'classification', 'lmnet_v1_group_conv'),
-            'expected_output_set_name': 'horse.png',
-            'prefix': 'gconv_cls',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '149_output:0.npy',
-            'hard_quantize': False,
-            'threshold_skipping': False,
-            'use_avx': False
-            }
-
-
-def dict_codegen_classification_cpu_hq_ts() -> dict:
-    """Test parameters for testing code generation for classification on CPU with both hard quantize
-       and threshold-skipping
-    """
-    return {'model_path': os.path.join('examples', 'classification', 'lmnet_quantize_cifar10_space_to_depth'),
-            'expected_output_set_name': '1000_dog.png',
-            'prefix': 'ts_cls',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '133_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': True,
-            'use_avx': False
-            }
-
-
-def dict_codegen_classification_fpga() -> dict:
-    """Test parameters for testing code generation for classification on FPGA
-    """
-    return {'model_path': os.path.join('examples', 'classification', 'lmnet_quantize_cifar10_space_to_depth'),
-            'expected_output_set_name': '1000_dog.png',
-            'prefix': 'fpga_cls',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '133_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': False,
-            'cpu_name': 'arm_fpga',
-            'need_arm_compiler': True,
-            'cache_dma': False,
-            }
-
-
-def dict_codegen_classification_resnet_fpga() -> dict:
-    """Test parameters for testing code generation for classification on FPGA
-    """
-    return {'model_path': os.path.join('examples', 'classification', 'resnet_quantize_cifar10'),
-            'expected_output_set_name': '9984_horse.png',
-            'prefix': 'fpga_cls_resnet',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '368_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': False,
-            'cpu_name': 'arm_fpga',
-            'need_arm_compiler': True,
-            'cache_dma': False,
-            }
-
-
-def dict_codegen_object_detection_fpga() -> dict:
-    """Test parameters for testing code generation for object detection on FPGA
-    """
-    return {'model_path': os.path.join('examples', 'object_detection', 'fyolo_quantize_4_v4'),
-            'expected_output_set_name': 'network_input_output',
-            'prefix': 'fpga_detection_fyolo',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '317_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': False,
-            'cpu_name': 'arm_fpga',
-            'need_arm_compiler': True,
-            'cache_dma': False,
-            }
-
-
-def dict_codegen_object_detection_widerface_fpga() -> dict:
-    """Test parameters for testing code generation for object detection on FPGA
-    """
-    return {'model_path': os.path.join('examples', 'object_detection', 'widerface_320'),
-            'expected_output_set_name': 'network_input_output',
-            'prefix': 'fpga_detection_widerface',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '337_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': False,
-            'cpu_name': 'arm_fpga',
-            'need_arm_compiler': True,
-            'cache_dma': False,
-            }
-
-
-def dict_codegen_object_detection_widerface_1x1_fpga() -> dict:
-    """Test parameters for testing code generation for object detection on FPGA
-    """
-    return {'model_path': os.path.join('examples', 'object_detection', 'widerface_v5'),
-            'expected_output_set_name': 'network_input_output',
-            'prefix': 'fpga_detection_widerface_1x1',
-            'input_name': '000_images_placeholder:0.npy',
-            'output_npy_name': '337_output:0.npy',
-            'hard_quantize': True,
-            'threshold_skipping': False,
-            'cpu_name': 'arm_fpga',
-            'need_arm_compiler': True,
-            'cache_dma': False,
-            }
-
-
-def dict_codegen_object_detection_x86() -> dict:
+def dict_codegen_object_detection(cpu_name) -> dict:
     """Test parameters for testing code generation for object detection on CPU"""
     return {'model_path': os.path.join('examples', 'object_detection', 'fyolo_quantize_4_v4'),
             'expected_output_set_name': 'network_input_output',
             'prefix': 'det',
             'input_name': '000_images_placeholder:0.npy',
             'output_npy_name': '317_output:0.npy',
-            'hard_quantize': False,
-            'threshold_skipping': False,
-            'use_avx': False
+            'cpu_name': cpu_name,
             }
 
 
-def dict_codegen_segmentation_x86() -> dict:
+def dict_codegen_segmentation(cpu_name) -> dict:
     """Test parameters for testing code generation for segmentation on CPU"""
     return {'model_path': os.path.join('examples', 'segmentation', 'lm_segnet_v1_quantize_camvid'),
             'expected_output_set_name': 'network_input_output',
             'prefix': 'seg',
             'input_name': '000_images_placeholder:0.npy',
             'output_npy_name': '227_output:0.npy',
-            'hard_quantize': False,
-            'threshold_skipping': False,
-            'use_avx': False
+            'cpu_name': cpu_name,
             }
 
+def get_configurations_by_test_cases(test_cases, configuration):
+    configurations = []
+    for test_case in test_cases:
+        configurations.append(updated_dict(configuration,test_case))
 
-def get_configurations():
-    configurations = [
-        # Classification / x86
-        dict_codegen_classification_x86(),
-        updated_dict(dict_codegen_classification_x86(), {'hard_quantize': True}),
-        updated_dict(dict_codegen_classification_x86(),
-                     {'hard_quantize': True,
-                      "input_name": 'raw_image.png', "use_run_test_script": True,
-                      "test_level": TEST_LEVEL_FUTURE_TARGET
-                      }),
-        updated_dict(dict_codegen_classification_x86(),
-                     {'hard_quantize': True, "input_name": 'preprocessed_image.npy',
-                      "use_run_test_script": True, "from_npy": True}),
+    return configurations
 
-        # Classification group convolution / x86
-        dict_codegen_group_conv_classification_x86(),
-        updated_dict(dict_codegen_group_conv_classification_x86(), {'hard_quantize': True}),
+def get_configurations_by_architecture(test_cases, cpu_name):
+    configurations = []
+    configurations.extend(get_configurations_by_test_cases(test_cases, dict_codegen_classification(cpu_name)))
+    configurations.extend(get_configurations_by_test_cases(test_cases, dict_codegen_classification_resnet(cpu_name)))
+    configurations.extend(get_configurations_by_test_cases(test_cases, dict_codegen_object_detection(cpu_name)))
+    configurations.extend(get_configurations_by_test_cases(test_cases, dict_codegen_segmentation(cpu_name)))
 
-        # Classification resnet / x86
-        dict_codegen_resnet_classification_x86(),
-        updated_dict(dict_codegen_resnet_classification_x86(), {'hard_quantize': True}),
-        updated_dict(dict_codegen_resnet_classification_x86(),
-                     {'hard_quantize': True, 'threshold_skipping': True}),
-
-        dict_codegen_classification_cpu_hq_ts(),
-
-        # Detection / x86
-        dict_codegen_object_detection_x86(),
-        updated_dict(dict_codegen_object_detection_x86(), {'hard_quantize': True}),
-        updated_dict(dict_codegen_object_detection_x86(),
-                     {'hard_quantize': True, 'threshold_skipping': True}),
-
-        # Segmentation / x86
-        dict_codegen_segmentation_x86(),
-        updated_dict(dict_codegen_segmentation_x86(), {'hard_quantize': True}),
-        updated_dict(dict_codegen_segmentation_x86(),
-                     {'hard_quantize': True, 'threshold_skipping': True}),
-
-        # Classification / x86 AVX
-        updated_dict(dict_codegen_classification_x86(), {'use_avx' : True}),
-        updated_dict(dict_codegen_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True}),
-        updated_dict(dict_codegen_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True,
-                      "input_name": 'raw_image.png', "use_run_test_script": True,
-                      "test_level": TEST_LEVEL_FUTURE_TARGET
-                      }),
-        updated_dict(dict_codegen_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True,
-                      "input_name": 'preprocessed_image.npy',
-                      "use_run_test_script": True, "from_npy": True}),
-
-        # Classification group convolution / x86 AVX
-        updated_dict(dict_codegen_group_conv_classification_x86(), {'use_avx': True}),
-        updated_dict(dict_codegen_group_conv_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True}),
-
-        # Classification resnet / x86 AVX
-        updated_dict(dict_codegen_resnet_classification_x86(), {'use_avx': True}),
-        updated_dict(dict_codegen_resnet_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True}),
-        updated_dict(dict_codegen_resnet_classification_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True,
-                      'threshold_skipping': True}),
-
-        updated_dict(dict_codegen_classification_cpu_hq_ts(), {'use_avx': True}),
-
-        # Detection / x86 AVX
-        updated_dict(dict_codegen_object_detection_x86(), {'use_avx': True}),
-        updated_dict(dict_codegen_object_detection_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True}),
-        updated_dict(dict_codegen_object_detection_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True,
-                      'threshold_skipping': True}),
-
-        # Segmentation / x86 AVX
-        updated_dict(dict_codegen_segmentation_x86(), {'use_avx': True}),
-        updated_dict(dict_codegen_segmentation_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True}),
-        updated_dict(dict_codegen_segmentation_x86(),
-                     {'hard_quantize': True,
-                      'use_avx': True,
-                      'threshold_skipping': True}),
-
-        # Classification FPGA
-        dict_codegen_classification_fpga(),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cache_dma': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': True}),
-
-        # Classification ResNet-18 on FPGA
-        dict_codegen_classification_resnet_fpga(),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cache_dma': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': True}),
-
-        # Detection on FPGA
-        dict_codegen_object_detection_fpga(),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cache_dma': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': True}),
-
-        # Detection WiderFace on FPGA
-        dict_codegen_object_detection_widerface_fpga(),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cache_dma': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': True}),
-
-        # Detection WiderFace 1x1 on FPGA
-        dict_codegen_object_detection_widerface_1x1_fpga(),
-        updated_dict(dict_codegen_object_detection_widerface_1x1_fpga(),
-                     {'cache_dma': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_object_detection_widerface_1x1_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_widerface_1x1_fpga(),
-                     {'cache_dma': True, 'threshold_skipping': True}),
-
-        # Classification ARM
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls', 'hard_quantize': False,
-                      'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls', 'hard_quantize': True,
-                      'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls', 'hard_quantize': False,
-                      'threshold_skipping': True}),
-        updated_dict(dict_codegen_classification_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls', 'hard_quantize': True,
-                      'threshold_skipping': True}),
-
-        # Classification ResNet-18 ARM
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls_rn', 'hard_quantize': False,
-                      'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls_rn', 'hard_quantize': True,
-                      'threshold_skipping': False}),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls_rn', 'hard_quantize': False,
-                      'threshold_skipping': True}),
-        updated_dict(dict_codegen_classification_resnet_fpga(),
-                     {'cpu_name': 'arm', 'prefix': 'arm_cls_rn', 'hard_quantize': True,
-                      'threshold_skipping': True}),
-
-        # Detection ARM
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det', 'hard_quantize': False, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det', 'hard_quantize': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det', 'hard_quantize': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_object_detection_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det', 'hard_quantize': True, 'threshold_skipping': True}),
-
-        # Detection WiderFace ARM
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det_wf', 'hard_quantize': False, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det_wf', 'hard_quantize': True, 'threshold_skipping': False}),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det_wf', 'hard_quantize': False, 'threshold_skipping': True}),
-        updated_dict(dict_codegen_object_detection_widerface_fpga(),
-                     {'cpu_name':'arm', 'prefix': 'arm_det_wf', 'hard_quantize': True, 'threshold_skipping': True}),
-   ]
-
-    return [(i, configuration) for i, configuration in enumerate(configurations)]
+    return configurations
 
 
-class TestCodeGeneration(TestCaseDLKBase):
+class TestCodeGenerationBase(TestCaseDLKBase):
     """Test class for code generation testing."""
 
-    @params(*get_configurations())
     def test_all_configuration(self, i, configuration) -> None:
 
+        print(f"\nCode_generation test: testcase {configuration}")
         #  TODO consider better implementation
         this_test_level = configuration.get("test_level", 0)
         if this_test_level < CURRENT_TEST_LEVEL:
@@ -602,7 +312,7 @@ class TestCodeGeneration(TestCaseDLKBase):
         self.assertTrue(percent_failed < max_percent_incorrect_values,
                         msg=f"Test failed: {percent_failed:.3f}% of the values does not match")
 
-        print(f"Codegen test {prefix}: passed!  {100.0 - percent_failed:.3f}% "
+        print(f"Binary exec test {prefix}: passed!  {100.0 - percent_failed:.3f}% "
               f"of the output values are correct\n"
               f"[hard quantize == {hard_quantize}, threshold skipping == {threshold_skipping}, cache == {cache_dma}]")
 

--- a/dlk/tests/test_code_generation_arm.py
+++ b/dlk/tests/test_code_generation_arm.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Test file for code generation"""
+from nose2.tools import params
+from test_code_generation import TestCodeGenerationBase, get_configurations_by_architecture
+from testcase_dlk_base import TestCaseFPGABase
+
+
+def get_configurations():
+    cpu_name = "arm"
+    test_cases = [
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': True, 'threshold_skipping': True},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': True, 'threshold_skipping': False},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': False, 'threshold_skipping': True},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': False, 'threshold_skipping': False},
+    ]
+    configurations = get_configurations_by_architecture(test_cases, cpu_name)
+
+    return [(i, configuration) for i, configuration in enumerate(configurations)]
+
+
+class TestCodeGenerationArm(TestCodeGenerationBase, TestCaseFPGABase):
+    """Test class for code generation testing."""
+
+    @params(*get_configurations())
+    def test_code_generation(self, i, configuration) -> None:
+        self.test_all_configuration(i, configuration)

--- a/dlk/tests/test_code_generation_arm_fpga.py
+++ b/dlk/tests/test_code_generation_arm_fpga.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Test file for code generation"""
+from nose2.tools import params
+from test_code_generation import TestCodeGenerationBase, get_configurations_by_architecture
+from testcase_dlk_base import TestCaseFPGABase
+
+
+def get_configurations():
+    cpu_name = "arm_fpga"
+    test_cases = [
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': True, 'threshold_skipping': True},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': True, 'threshold_skipping': False},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': False, 'threshold_skipping': True},
+        {'hard_quantize': True, 'need_arm_compiler': True, 'cache_dma': False, 'threshold_skipping': False},
+    ]
+    configurations = get_configurations_by_architecture(test_cases, cpu_name)
+
+    return [(i, configuration) for i, configuration in enumerate(configurations)]
+
+
+class TestCodeGenerationArmFpga(TestCodeGenerationBase, TestCaseFPGABase):
+    """Test class for code generation testing."""
+
+    @params(*get_configurations())
+    def test_code_generation(self, i, configuration) -> None:
+        self.test_all_configuration(i, configuration)

--- a/dlk/tests/test_code_generation_x86_64.py
+++ b/dlk/tests/test_code_generation_x86_64.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Test file for code generation"""
+from nose2.tools import params
+from test_code_generation import TestCodeGenerationBase, get_configurations_by_architecture
+from test_code_generation import get_configurations_by_test_cases, dict_codegen_classification
+from tstutils import updated_dict, TEST_LEVEL_FUTURE_TARGET
+
+
+def get_configurations():
+    cpu_name = "x86_64"
+    test_cases = [
+        {'use_avx': True, 'hard_quantize': True, 'threshold_skipping': True},
+        {'use_avx': True, 'hard_quantize': True, 'threshold_skipping': False},
+        {'use_avx': True, 'hard_quantize': False, 'threshold_skipping': False},
+        {'use_avx': False, 'hard_quantize': True, 'threshold_skipping': True},
+        {'use_avx': False, 'hard_quantize': True, 'threshold_skipping': False},
+        {'use_avx': False, 'hard_quantize': False, 'threshold_skipping': False},
+    ]
+    configurations = get_configurations_by_architecture(test_cases, cpu_name)
+
+    additional_test_configuration = updated_dict(dict_codegen_classification(cpu_name),
+                                                 {'hard_quantize': True, 'use_run_test_script': True})
+    additional_test_cases = [
+        {'use_avx': True, 'input_name': 'raw_image.png', 'test_level': TEST_LEVEL_FUTURE_TARGET},
+        {'use_avx': True, 'input_name': 'preprocessed_image.npy', 'from_npy': True},
+        {'use_avx': False, 'input_name': 'raw_image.png', 'test_level': TEST_LEVEL_FUTURE_TARGET},
+        {'use_avx': False, 'input_name': 'preprocessed_image.npy', 'from_npy': True},
+    ]
+    configurations.extend(get_configurations_by_test_cases(additional_test_cases, additional_test_configuration))
+
+    return [(i, configuration) for i, configuration in enumerate(configurations)]
+
+
+class TestCodeGenerationX8664(TestCodeGenerationBase):
+    """Test class for code generation testing."""
+
+    @params(*get_configurations())
+    def test_code_generation(self, i, configuration) -> None:
+        self.test_all_configuration(i, configuration)

--- a/dlk/tests/testcase_dlk_base.py
+++ b/dlk/tests/testcase_dlk_base.py
@@ -42,17 +42,6 @@ class TestCaseDLKBase(TestCase):
     """
     build_dir = None
 
-    @classmethod
-    def setUpClass(TestCaseDLKBase):
-        # Setup the board. For now, DE10 Nano board
-        output_path = '/tmp'
-        hw_path = os.path.abspath(os.path.join('..', FPGA_FILES))
-
-        board_available = setup_de10nano(hw_path, output_path)
-
-        if not board_available:
-            raise Exception('Not FPGA found: cannot test')
-
     def setUp(self) -> None:
         """
         Cleanup old build directory and make build directory
@@ -77,3 +66,22 @@ class TestCaseDLKBase(TestCase):
     def tearDown(self) -> None:
         if DO_CLEANUP:
             rmdir(self.build_dir)
+
+
+class TestCaseFPGABase(TestCaseDLKBase):
+    """
+    This is base class for FPGA TestCase which have
+    Setup and TearDown method.
+    """
+    build_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Setup the board. For now, DE10 Nano board
+        output_path = '/tmp'
+        hw_path = os.path.abspath(os.path.join('..', FPGA_FILES))
+
+        board_available = setup_de10nano(hw_path, output_path)
+
+        if not board_available:
+            raise Exception('Not FPGA found: cannot test')


### PR DESCRIPTION
Step 1 of #477 

I changed test cases to inherit base-file definition, use inputs of table testing and separated test files of each architecture for running each test separately.

| Task | Model | x86_64 | ARM | ARM_FPGA |
| --- | --- | --- | --- | --- |
| classification | lmnet_quantize_cifar10_space_to_depth | o | o | o |
| classification | resnet_quantize_cifar10 | o | o | o |
| object_detection | fyolo_quantize_4_v4 | o | o | o |
| segmentation | lm_segnet_v1_quantize_camvid | o | o | o |

<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
