### PR TITLE
Add fpga_setup flag for setUpClass

### DIFF
--- a/dlk/tests/test_code_generation.py
+++ b/dlk/tests/test_code_generation.py
@@ -392,6 +392,8 @@ class TestCodeGenerationX8664(TestCodeGenerationBase):
 class TestCodeGenerationArm(TestCodeGenerationBase):
     """Test class for code generation testing."""
 
+    fpga_setup = True
+
     @params(*get_configurations_arm())
     def test_code_generation(self, i, configuration) -> None:
         self.run_test_all_configuration(i, configuration)
@@ -399,6 +401,8 @@ class TestCodeGenerationArm(TestCodeGenerationBase):
 
 class TestCodeGenerationArmFpga(TestCodeGenerationBase):
     """Test class for code generation testing."""
+
+    fpga_setup = True
 
     @params(*get_configurations_arm_fpga())
     def test_code_generation(self, i, configuration) -> None:

--- a/dlk/tests/testcase_dlk_base.py
+++ b/dlk/tests/testcase_dlk_base.py
@@ -41,9 +41,13 @@ class TestCaseDLKBase(TestCase):
     Setup and TearDown method which is common in dlk project.
     """
     build_dir = None
+    fpga_setup = False
 
     @classmethod
-    def setUpClass(TestCaseDLKBase):
+    def setUpClass(cls):
+        if not cls.fpga_setup:
+            return
+
         # Setup the board. For now, DE10 Nano board
         output_path = '/tmp'
         hw_path = os.path.abspath(os.path.join('..', FPGA_FILES))


### PR DESCRIPTION
Related Step1 of #477
Separated PR of #490 for reviewability

<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Currently, in the test case of x86_64, FPGA will be set up. However, that is unnecessary.
Add fpga_setup flag for setUpClass to avoid unnecessary setup.
## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.