### PR TITLE
Optimize func_QTZ_linear_mid_tread_half for float output

### DIFF
--- a/dlk/python/dlk/templates/src/matrix/shift_add.cpp
+++ b/dlk/python/dlk/templates/src/matrix/shift_add.cpp
@@ -30,8 +30,7 @@ namespace dlk {
 template<>
 void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
                       MatrixView<float, MatrixOrder::ColMajor>& result,
-                      const struct convolution_parameters& p,
-                      const int block_offset) {
+                      const struct convolution_parameters& p) {
   Measurement::Start("matrix_shift_add_f1");
 
   const int h = p.input_height;
@@ -39,19 +38,15 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
   const int oc = p.output_channels;
   const int kh = p.kernel_height;
   const int kw = p.kernel_width;
-  const auto col_block = buf.cols();
 
   // only 3x3 kernel is supported.
   assert(kh == 3 && kw == 3);
 
-  for (unsigned int j = 0; j < col_block; ++j) {
-    const bool is_first = is_first_column(j + block_offset, w);
-    const bool is_last = is_last_column(j + block_offset, w);
-    if (!is_first && !is_last) continue;
+  for (unsigned int j = 0; j < buf.cols(); ++j) {
     for (unsigned int i = 0; i < buf.rows(); ++i) {
-      if (is_first && is_cfi(i, p.output_channels)) {
+      if (is_first_column(j, w) && is_cfi(i, p.output_channels)) {
         buf.set(i, j, 0);
-      } else if (is_last && is_adg(i, p.output_channels)) {
+      } else if (is_last_column(j, w) && is_adg(i, p.output_channels)) {
         buf.set(i, j, 0);
       }
     }
@@ -60,20 +55,16 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
   Measurement::Stop();
 
   Measurement::Start("matrix_shift_add_f2");
-
-  const auto res_col_start = std::max(0, block_offset - w - 1);
-  const auto res_col_end = std::min(h * w, block_offset + col_block + w + 1);
 #pragma omp parallel for
-  for (int k = res_col_start; k < res_col_end; ++k) {
-    const auto buf_k = k - block_offset;
-    for (unsigned int i = 0; i < kh * kw; ++i) {
+  for (int k = 0; k < h * w; ++k) {
+    for (unsigned int i = 0; i < (kh * kw); ++i) {
       int offset = calc_offset(i, w);
-      if ((buf_k - offset < 0) || (buf_k - offset >= col_block)) {
+      if ((k - offset < 0) || (k - offset >= (h * w))) {
         continue;
       }
 
       float* r = result.data(0, k);
-      float* b = buf.data(i*oc, buf_k - offset);
+      float* b = buf.data(i*oc, k - offset);
 
 
       unsigned int j = 0;
@@ -104,8 +95,7 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
 template<>
 void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
                       MatrixView<int32_t, MatrixOrder::ColMajor>& result,
-                      const struct convolution_parameters& p,
-                      const int block_offset) {
+                      const struct convolution_parameters& p) {
   Measurement::Start("matrix_shift_add_i1");
 
   const int h = p.input_height;
@@ -113,16 +103,15 @@ void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
   const int oc = p.output_channels;
   const int kh = p.kernel_height;
   const int kw = p.kernel_width;
-  const auto col_block = buf.cols();
 
   // only 3x3 kernel is supported.
   assert(kh == 3 && kw == 3);
 
-  for (unsigned int j = 0; j < col_block; ++j) {
+  for (unsigned int j = 0; j < buf.cols(); ++j) {
     for (unsigned int i = 0; i < buf.rows(); ++i) {
-      if (is_first_column(j + block_offset, w) && is_cfi(i, p.output_channels)) {
+      if (is_first_column(j, w) && is_cfi(i, p.output_channels)) {
         buf.set(i, j, 0);
-      } else if (is_last_column(j + block_offset, w) && is_adg(i, p.output_channels)) {
+      } else if (is_last_column(j, w) && is_adg(i, p.output_channels)) {
         buf.set(i, j, 0);
       }
     }
@@ -132,19 +121,16 @@ void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
 
   Measurement::Start("matrix_shift_add_i2");
 
-  const auto res_col_start = std::max(0, block_offset - w - 1);
-  const auto res_col_end = std::min(h * w, block_offset + col_block + w + 1);
 #pragma omp parallel for
-  for (int k = res_col_start; k < res_col_end; ++k) {
-    const auto buf_k = k - block_offset;
+  for (int k = 0; k < h * w; ++k) {
     for (unsigned int i = 0; i < kh * kw; ++i) {
       int offset = calc_offset(i, w);
-      if ((buf_k - offset < 0) || (buf_k - offset >= col_block)) {
+      if ((k - offset < 0) || (k - offset >= h * w)) {
         continue;
       }
 
       int32_t* r = result.data(0, k);
-      int32_t* b = buf.data(i*oc, buf_k - offset);
+      int32_t* b = buf.data(i*oc, k - offset);
 
 
       unsigned int j = 0;

--- a/dlk/python/dlk/templates/src/matrix/shift_add.cpp
+++ b/dlk/python/dlk/templates/src/matrix/shift_add.cpp
@@ -30,7 +30,8 @@ namespace dlk {
 template<>
 void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
                       MatrixView<float, MatrixOrder::ColMajor>& result,
-                      const struct convolution_parameters& p) {
+                      const struct convolution_parameters& p,
+                      const int block_offset) {
   Measurement::Start("matrix_shift_add_f1");
 
   const int h = p.input_height;
@@ -38,15 +39,19 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
   const int oc = p.output_channels;
   const int kh = p.kernel_height;
   const int kw = p.kernel_width;
+  const auto col_block = buf.cols();
 
   // only 3x3 kernel is supported.
   assert(kh == 3 && kw == 3);
 
-  for (unsigned int j = 0; j < buf.cols(); ++j) {
+  for (unsigned int j = 0; j < col_block; ++j) {
+    const bool is_first = is_first_column(j + block_offset, w);
+    const bool is_last = is_last_column(j + block_offset, w);
+    if (!is_first && !is_last) continue;
     for (unsigned int i = 0; i < buf.rows(); ++i) {
-      if (is_first_column(j, w) && is_cfi(i, p.output_channels)) {
+      if (is_first && is_cfi(i, p.output_channels)) {
         buf.set(i, j, 0);
-      } else if (is_last_column(j, w) && is_adg(i, p.output_channels)) {
+      } else if (is_last && is_adg(i, p.output_channels)) {
         buf.set(i, j, 0);
       }
     }
@@ -55,16 +60,20 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
   Measurement::Stop();
 
   Measurement::Start("matrix_shift_add_f2");
+
+  const auto res_col_start = std::max(0, block_offset - w - 1);
+  const auto res_col_end = std::min(h * w, block_offset + col_block + w + 1);
 #pragma omp parallel for
-  for (int k = 0; k < h * w; ++k) {
-    for (unsigned int i = 0; i < (kh * kw); ++i) {
+  for (int k = res_col_start; k < res_col_end; ++k) {
+    const auto buf_k = k - block_offset;
+    for (unsigned int i = 0; i < kh * kw; ++i) {
       int offset = calc_offset(i, w);
-      if ((k - offset < 0) || (k - offset >= (h * w))) {
+      if ((buf_k - offset < 0) || (buf_k - offset >= col_block)) {
         continue;
       }
 
       float* r = result.data(0, k);
-      float* b = buf.data(i*oc, k - offset);
+      float* b = buf.data(i*oc, buf_k - offset);
 
 
       unsigned int j = 0;
@@ -95,7 +104,8 @@ void matrix_shift_add(MatrixView<float, MatrixOrder::ColMajor>& buf,
 template<>
 void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
                       MatrixView<int32_t, MatrixOrder::ColMajor>& result,
-                      const struct convolution_parameters& p) {
+                      const struct convolution_parameters& p,
+                      const int block_offset) {
   Measurement::Start("matrix_shift_add_i1");
 
   const int h = p.input_height;
@@ -103,15 +113,16 @@ void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
   const int oc = p.output_channels;
   const int kh = p.kernel_height;
   const int kw = p.kernel_width;
+  const auto col_block = buf.cols();
 
   // only 3x3 kernel is supported.
   assert(kh == 3 && kw == 3);
 
-  for (unsigned int j = 0; j < buf.cols(); ++j) {
+  for (unsigned int j = 0; j < col_block; ++j) {
     for (unsigned int i = 0; i < buf.rows(); ++i) {
-      if (is_first_column(j, w) && is_cfi(i, p.output_channels)) {
+      if (is_first_column(j + block_offset, w) && is_cfi(i, p.output_channels)) {
         buf.set(i, j, 0);
-      } else if (is_last_column(j, w) && is_adg(i, p.output_channels)) {
+      } else if (is_last_column(j + block_offset, w) && is_adg(i, p.output_channels)) {
         buf.set(i, j, 0);
       }
     }
@@ -121,16 +132,19 @@ void matrix_shift_add(MatrixView<int32_t, MatrixOrder::ColMajor>& buf,
 
   Measurement::Start("matrix_shift_add_i2");
 
+  const auto res_col_start = std::max(0, block_offset - w - 1);
+  const auto res_col_end = std::min(h * w, block_offset + col_block + w + 1);
 #pragma omp parallel for
-  for (int k = 0; k < h * w; ++k) {
+  for (int k = res_col_start; k < res_col_end; ++k) {
+    const auto buf_k = k - block_offset;
     for (unsigned int i = 0; i < kh * kw; ++i) {
       int offset = calc_offset(i, w);
-      if ((k - offset < 0) || (k - offset >= h * w)) {
+      if ((buf_k - offset < 0) || (buf_k - offset >= col_block)) {
         continue;
       }
 
       int32_t* r = result.data(0, k);
-      int32_t* b = buf.data(i*oc, k - offset);
+      int32_t* b = buf.data(i*oc, buf_k - offset);
 
 
       unsigned int j = 0;

--- a/dlk/python/dlk/templates/src/quantizer.cpp
+++ b/dlk/python/dlk/templates/src/quantizer.cpp
@@ -194,8 +194,56 @@ void func_QTZ_linear_mid_tread_half(
   T_FLOAT min_value = 0.f;
   T_FLOAT n = (1 << nbit()) - 1.f;
   unsigned num_elems = input.size();
+  const auto coeff = n / max_value();
+  const auto inv_coeff = max_value() / n;
 
-  for (unsigned i = 0; i < num_elems; i++)
+  unsigned i = 0;
+#ifdef USE_NEON
+  constexpr std::size_t SIMD_WIDTH = 4;
+  const auto num_elems_floor = num_elems - num_elems % SIMD_WIDTH;
+  const auto max_value_v = vdupq_n_f32(max_value());
+  const auto min_value_v = vdupq_n_f32(min_value);
+  const auto coeff_v = vdupq_n_f32(coeff);
+  const auto inv_coeff_v = vdupq_n_f32(inv_coeff);
+#pragma omp parallel for
+  for (unsigned i = 0; i < num_elems_floor; i += SIMD_WIDTH)
+  {
+    const auto in = vld1q_f32(input.data() + i);
+    const auto lbounded = vmaxq_f32(in, min_value_v);
+    const auto ubounded = vminq_f32(lbounded, max_value_v);
+    const auto normed = vmulq_f32(ubounded, coeff_v);
+#ifdef AARCH32
+    const auto biased = vaddq_f32(normed, vdupq_n_f32(0.5f));
+    const auto rounded_i = vcvtq_s32_f32(biased);
+    const auto rounded = vcvtq_f32_s32(rounded_i);
+#else
+    const auto rounded = vrndnq_f32(normed);
+#endif
+    const auto result = vmulq_f32(rounded, inv_coeff_v);
+    vst1q_f32(output.data() + i, result);
+  }
+  i = num_elems_floor;
+#elif defined USE_AVX
+  constexpr std::size_t SIMD_WIDTH = 8;
+  const auto num_elems_floor = num_elems - num_elems % SIMD_WIDTH;
+  const auto max_value_v = _mm256_set1_ps(max_value());
+  const auto min_value_v = _mm256_set1_ps(min_value);
+  const auto coeff_v = _mm256_set1_ps(coeff);
+  const auto inv_coeff_v = _mm256_set1_ps(inv_coeff);
+#pragma omp parallel for
+  for (unsigned i = 0; i < num_elems_floor; i += SIMD_WIDTH)
+  {
+    const auto in = _mm256_loadu_ps(input.data() + i);
+    const auto lbounded = _mm256_max_ps(in, min_value_v);
+    const auto ubounded = _mm256_min_ps(lbounded, max_value_v);
+    const auto normed = _mm256_mul_ps(ubounded, coeff_v);
+    const auto rounded = _mm256_round_ps(normed, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    const auto result = _mm256_mul_ps(rounded, inv_coeff_v);
+    _mm256_storeu_ps(output.data() + i, result);
+  }
+  i = num_elems_floor;
+#endif
+  for (; i < num_elems; i++)
   {
     T_FLOAT tmp = std::max(input.data()[i], min_value);
     tmp = std::min(tmp, max_value());


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

func_QTZ_linear_mid_tread_half for float output 14x faster on x86 with AVX2!

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

func_QTZ_linear_mid_tread_half was optimized only for packed int output.
This PR provide float output optimization.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

- Use OpenMP
- Use AVX/NEON

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
