### PR TITLE
create docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.6"
+services:
+  blueoil:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      # https://docs.nvidia.com/deeplearning/frameworks/user-guide/index.html#run_tf_cifar10
+      shm_size: "1gb"
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    working_dir: /home/blueoil
+    volumes:
+      - ./:/home/blueoil
+      - ${DATA_DIR:-/storage/dataset}:/storage/dataset
+    environment:
+      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+      - DATA_DIR=/storage/dataset
+      - OUTPUT_DIR=/home/blueoil/saved
+      - PYTHONPATH=/home/blueoil:/home/blueoil/lmnet:/home/blueoil/dlk/python/dlk


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

In the blueoil rebuilding project, we planned to use `make` to run the blueoil command on docker.
But, `make` cannot passthrough command line args.
Therefore I created docker-compose.yml to use the docker command easily.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

- create `docker-compose.yml`

I will remove `blueoil.sh` after add tests.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

### train
```
DATA_DIR=/storage/suttang/dataset/Caltech101/101_ObjectCategories/ CUDA_VISIBLE_DEVICES=4 docker-compose run --rm --user="$(id -u):$(id -g)" blueoil python blueoil/cmd/main.py train -c ./caltech-test-docker-compose.yml
```

**horovod**
```
DATA_DIR=/storage/suttang/dataset/Caltech101/101_ObjectCategories/ CUDA_VISIBLE_DEVICES=0,1,2,3,4 docker-compose run --rm --user="$(id -u):$(id -g)" blueoil horovodrun -np 5 python blueoil/cmd/main.py train -c ./caltech-test-docker-compose.yml
```

### convert
```
CUDA_VISIBLE_DEVICES=4 docker-compose run --rm --user="$(id -u):$(id -g)" blueoil python blueoil/cmd/main.py convert -e train_20191016033908 -p save.ckpt-769
```

### predict
```
CUDA_VISIBLE_DEVICES=4 docker-compose run --rm --user="$(id -u):$(id -g)" -v /storage/suttang/dataset/orange:/storage/predict_images blueoil python blueoil/cmd/main.py predict -i /storage/predict_images -o predict_result -e train_20191016033908
```

### tensorboard
```
tensorboard --logdir=saved/train_20191016033908
```

<details>
<summary>config</summary>

# supported task types are 'classification', 'object_detection' and 'semantic_segmentation'.
task_type: classification

network_name: LmnetV1Quantize

dataset:
  format: Caltech101
  train_path: /storage/dataset/
  test_path: 

trainer:
  batch_size: 10
  epochs: 200
  # supported 'optimizer' is 'Momentum', 'Adam' currently.
  # Momentum
  #    https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
  # Adam
  #    https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
  optimizer: Momentum
  # supported 'learning_rate_schedule' is 'constant', '2-step-decay', '3-step-decay', '3-step-decay-with-warmup' ({epochs} is the number of training epochs you entered before).
  #   'constant' -> constant learning rate.
  #   '2-step-decay' -> learning rate decrease by 1/10 on {epochs}/2 and {epochs}-1.
  #   '3-step-decay' -> learning rate decrease by 1/10 on {epochs}/3 and {epochs}*2/3 and {epochs}-1.
  #   '3-step-decay-with-warmup' -> warmup learning rate 1/1000 in first epoch, then train the same way as '3-step-decay'.
  learning_rate_schedule: constant
  initial_learning_rate: 0.001
  save_checkpoint_steps: 1000
  keep_checkpoint_max: 5

network:
  quantize_first_convolution: no

common:
  image_size:
    - 128  # height
    - 128  # width

  # set pretrain model name. currently, this feature is not supported, always ignored.
  pretrain_model: false

  # enable dataset prefetch, set false if weired problem happens
  dataset_prefetch: true
``
</details>

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
