### PR TITLE
Fix import error without FPGA_HOST

### DIFF
--- a/dlk/tests/tstutils.py
+++ b/dlk/tests/tstutils.py
@@ -22,7 +22,7 @@ from os.path import join
 from tstconf import DO_CLEANUP
 
 TEST_LEVEL_FUTURE_TARGET=512
-FPGA_HOST = os.environ['FPGA_HOST']
+FPGA_HOST = os.getenv('FPGA_HOST')
 
 
 def updated_dict(src_dict, updation) -> dict:
@@ -138,6 +138,9 @@ def wait_for_device(host: str, tries: int, seconds: int, log_path: str, testcase
 def setup_de10nano(hw_path: str, output_path: str, testcase=None):
 
     host = FPGA_HOST
+    if host is None:
+        return False
+
     available = wait_for_device(host, 15, 10, output_path, testcase)
     if not available:
         return False


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
`os.environ['FPGA_HOST']` will raise an error without `FPGA_HOST` environment variable, we cannot import `tstutills` without `FPGA_HOST`, so we cannot run a test for x86_64 locally without FPGA.
I fixed it.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
