### PR TITLE
make global_step available from all networks

### DIFF
--- a/lmnet/lmnet/networks/object_detection/lm_fyolo.py
+++ b/lmnet/lmnet/networks/object_detection/lm_fyolo.py
@@ -30,7 +30,7 @@ class LMFYolo(YoloV2):
         YoloV2 https://arxiv.org/abs/1612.08242
     """
 
-    def train(self, loss, optimizer, global_step=tf.Variable(0, trainable=False), var_list=[]):
+    def train(self, loss, optimizer, var_list=[]):
         with tf.name_scope("train"):
             if var_list == []:
                 var_list = tf.trainable_variables()
@@ -42,7 +42,7 @@ class LMFYolo(YoloV2):
                 (tf.clip_by_value(gradient, -10.0, 10.0), var)
                 for gradient, var in gradients
             ]
-            train_op = optimizer.apply_gradients(gradients, global_step=global_step)
+            train_op = optimizer.apply_gradients(gradients, global_step=self.global_step)
 
         for grad, var in gradients:
             if grad is not None:

--- a/lmnet/lmnet/networks/object_detection/yolo_v2.py
+++ b/lmnet/lmnet/networks/object_detection/yolo_v2.py
@@ -646,7 +646,7 @@ class YoloV2(BaseNetwork):
 
         return results
 
-    def loss(self, output, gt_boxes, global_step):
+    def loss(self, output, gt_boxes):
         """Loss.
 
         Args:
@@ -661,7 +661,7 @@ class YoloV2(BaseNetwork):
             predict_boxes = self.convert_boxes_space_from_yolo_to_real(predict_boxes)
 
         gt_boxes = self.convert_gt_boxes_xywh_to_cxcywh(gt_boxes)
-        return self.loss_function(predict_classes, predict_confidence, predict_boxes, gt_boxes, global_step)
+        return self.loss_function(predict_classes, predict_confidence, predict_boxes, gt_boxes, self.global_step)
 
     def inference(self, images, is_training):
         tf.summary.histogram("images", images)


### PR DESCRIPTION
# Motivation and Context

Currently, `global_step` variable which describes how many training steps were executed, is only available in object detection networks.

However, sometimes I want to use this variable in other kind of networks like classification networks.

## Description

This pull request changes how global_step variable is passed to network object.

- Current: passed by argument of `loss()` method and `train()` method
- This PR: passed by argument of network object constructor

## How has this been tested?

unit test

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
