### PR TITLE
Add inference benchmark option in run.py

### DIFF
--- a/output_template/python/lmnet/utils/output.py
+++ b/output_template/python/lmnet/utils/output.py
@@ -33,12 +33,13 @@ class JsonOutput():
     Plsease see [Output Data Specification](https://github.com/LeapMind/lmnet/wiki/Output-Data-Specification).
     """
 
-    def __init__(self, task, classes, image_size, data_format):
+    def __init__(self, task, classes, image_size, data_format, bench=None):
         assert task in Tasks
         self.task = task
         self.classes = classes
         self.image_size = image_size
         self.data_format = data_format
+        self.bench = bench
 
     def _classification(self, outputs, raw_images, image_files):
         assert outputs.shape == (len(image_files), len(self.classes))
@@ -158,6 +159,9 @@ class JsonOutput():
             "date": datetime.now().isoformat(),
             "results": [],
         }
+
+        if self.bench is not None and type(self.bench) is dict:
+            result_json.update({"benchmark": self.bench})
 
         if self.task == Tasks.CLASSIFICATION:
 

--- a/output_template/python/lmnet/utils/output.py
+++ b/output_template/python/lmnet/utils/output.py
@@ -33,13 +33,13 @@ class JsonOutput():
     Plsease see [Output Data Specification](https://github.com/LeapMind/lmnet/wiki/Output-Data-Specification).
     """
 
-    def __init__(self, task, classes, image_size, data_format, bench=None):
+    def __init__(self, task, classes, image_size, data_format, bench={}):
         assert task in Tasks
         self.task = task
         self.classes = classes
         self.image_size = image_size
         self.data_format = data_format
-        self.bench = bench
+        self.bench = {}
 
     def _classification(self, outputs, raw_images, image_files):
         assert outputs.shape == (len(image_files), len(self.classes))
@@ -158,10 +158,8 @@ class JsonOutput():
             "classes": [{"id": i, "name": class_name} for i, class_name in enumerate(self.classes)],
             "date": datetime.now().isoformat(),
             "results": [],
+            "benchmark": self.bench,
         }
-
-        if self.bench is not None and type(self.bench) is dict:
-            result_json.update({"benchmark": self.bench})
 
         if self.task == Tasks.CLASSIFICATION:
 

--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -55,7 +55,7 @@ def _save_json(output_dir, json_obj):
         os.makedirs(dirname)
     with open(output_file_name, "w") as json_file:
         json_file.write(json_obj)
-    logging.info("save json: {}".format(output_file_name))
+    logger.info("save json: {}".format(output_file_name))
 
 
 def _save_images(output_dir, filename_images):
@@ -66,7 +66,7 @@ def _save_images(output_dir, filename_images):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
         image.save(output_file_name)
-        logging.info("save image: {}".format(output_file_name))
+        logger.info("save image: {}".format(output_file_name))
 
 
 def _run(model, image_data, config):
@@ -111,15 +111,10 @@ def _timerfunc(func, extraArgs, trial):
     return value, runtime / trial
 
 
-def run_prediction(input_image, model, config_file, max_percent_incorrect_values=0.1, bench=False, trial=1):
+def run_prediction(input_image, model, config_file, max_percent_incorrect_values=0.1, trial=1):
     if not input_image or not model or not config_file:
         logger.error('Please check usage with --help option')
         exit(1)
-
-    if bench is False:
-        trial = 1
-    else:
-        logger.info("Beanchmark mode is triggered with {} times trial".format(trial))
 
     config = load_yaml(config_file)
 
@@ -201,26 +196,20 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
     help="Config file Path",
 )
 @click.option(
-    "--bench",
-    help="Enable Benchmark mode",
-    is_flag=True,
-    default=False,
-)
-@click.option(
     "--trial",
     help="# of trial for Benchmark",
     type=click.INT,
     default=1,
 )
-def main(input_image, model, config_file, bench, trial):
+def main(input_image, model, config_file, trial):
     _check_deprecated_arguments()
-    run_prediction(input_image, model, config_file, bench, trial)
+    run_prediction(input_image, model, config_file, trial)
 
 
 def _check_deprecated_arguments():
     argument_list = sys.argv
     if '-l' in argument_list:
-        logger.info("Deprecated warning: -l is deprecated please use -m instead")
+        logger.warn("Deprecated warning: -l is deprecated please use -m instead")
 
 
 if __name__ == "__main__":

--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -71,14 +71,13 @@ def _save_images(output_dir, filename_images):
 
 def _run(model, image_data, config):
     filename, file_extension = os.path.splitext(model)
-    supported_files = ['.so', '.pb', '.elf']
+    supported_files = ['.so', '.pb']
 
     if file_extension not in supported_files:
         raise Exception("""
             Unknown file type. Got %s%s.
             Please check the model file (-m).
-            Only .pb (protocol buffer), .so (shared object)
-            or .elf (linux executable) file is supported.file is supported.
+            Only .pb (protocol buffer), .so (shared object) file is supported.
             """ % (filename, file_extension))
 
     if file_extension == '.so':  # Shared library
@@ -92,9 +91,6 @@ def _run(model, image_data, config):
         from lmnet.tensorflow_graph_runner import TensorflowGraphRunner
         nn = TensorflowGraphRunner(model)
         nn.init()
-
-    elif file_extension == '.elf':  # Linux executable
-        pass # TODO: kchygoe imprement
 
     # run the graph
     output = nn.run(image_data)
@@ -171,7 +167,6 @@ def run_prediction_with_bench(input_image, model, config_file, max_percent_incor
         logger.error('Please check usage with --help option')
         exit(1)
     config = load_yaml(config_file)
-    logger.warn("trial: {}".format(trial))
 
     # load the image
     image_data = load_image(input_image)
@@ -192,7 +187,6 @@ def run_prediction_with_bench(input_image, model, config_file, max_percent_incor
     output, bench_post = _timerfunc(_post_process, (output, config.POST_PROCESSOR), trial)
 
     logging.info('Output: (after post process)\n{}'.format(output))
-
 
     # json output
     json_output = JsonOutput(
@@ -249,7 +243,7 @@ def run_prediction_with_bench(input_image, model, config_file, max_percent_incor
 )
 @click.option(
     "--bench",
-    help="Enable Benchmark",
+    help="Enable Benchmark mode",
     is_flag=True,
     default=False,
 )
@@ -262,7 +256,7 @@ def run_prediction_with_bench(input_image, model, config_file, max_percent_incor
 def main(input_image, model, config_file, bench, trial):
     _check_deprecated_arguments()
     if bench is True:
-        logger.info("Beanchmark is triggered with {} times trial".format(trial))
+        logger.info("Beanchmark mode is triggered with {} times trial".format(trial))
         run_prediction_with_bench(input_image, model, config_file, trial=trial)
     else:
         run_prediction(input_image, model, config_file)

--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -15,8 +15,10 @@
 # =============================================================================
 import numpy as np
 import click
+import logging
 import os
 import sys
+import time
 
 from lmnet.nnlib import NNLib as NNLib
 
@@ -28,6 +30,8 @@ from lmnet.utils.config import (
     build_pre_process,
     build_post_process,
 )
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 
 def _pre_process(raw_image, pre_processor, data_format):
@@ -51,7 +55,7 @@ def _save_json(output_dir, json_obj):
         os.makedirs(dirname)
     with open(output_file_name, "w") as json_file:
         json_file.write(json_obj)
-    print("save json: {}".format(output_file_name))
+    logging.info("save json: {}".format(output_file_name))
 
 
 def _save_images(output_dir, filename_images):
@@ -62,30 +66,20 @@ def _save_images(output_dir, filename_images):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
         image.save(output_file_name)
-        print("save image: {}".format(output_file_name))
+        logging.info("save image: {}".format(output_file_name))
 
 
-def _run(model, input_image, config):
+def _run(model, image_data, config):
     filename, file_extension = os.path.splitext(model)
-    supported_files = ['.so', '.pb']
+    supported_files = ['.so', '.pb', '.elf']
 
     if file_extension not in supported_files:
         raise Exception("""
             Unknown file type. Got %s%s.
             Please check the model file (-m).
-            Only .pb (protocol buffer) or .so (shared object) file is supported.
+            Only .pb (protocol buffer), .so (shared object)
+            or .elf (linux executable) file is supported.file is supported.
             """ % (filename, file_extension))
-
-    # load the image
-    data = load_image(input_image)
-
-    raw_image = data
-
-    # pre process for image
-    data = _pre_process(data, config.PRE_PROCESSOR, config.DATA_FORMAT)
-
-    # add the batch dimension
-    data = np.expand_dims(data, axis=0)
 
     if file_extension == '.so':  # Shared library
         # load and initialize the generated shared model
@@ -99,30 +93,54 @@ def _run(model, input_image, config):
         nn = TensorflowGraphRunner(model)
         nn.init()
 
-    # run the graph
-    output = nn.run(data)
+    elif file_extension == '.elf':  # Linux executable
+        pass # TODO: kchygoe imprement
 
-    return output, raw_image
+    # run the graph
+    output = nn.run(image_data)
+
+    return output
+
+
+def _timerfunc(func, extraArgs, trial):
+    runtime = 0.
+    for i in range(0, trial):
+        start = time.process_time()
+        value = func(*extraArgs)
+        end = time.process_time()
+        runtime += end - start
+        msg = "Function {func} took {time} seconds to complete"
+        logger.info(msg.format(func=func.__name__, time=end - start))
+    logger.info("Avg(func {}): {} sec.".format(func.__name__, runtime / trial))
+    return value, runtime / trial
 
 
 def run_prediction(input_image, model, config_file, max_percent_incorrect_values=0.1):
     if not input_image or not model or not config_file:
-        print('Please check usage with --help option')
+        logger.error('Please check usage with --help option')
         exit(1)
 
     config = load_yaml(config_file)
 
-    # run the model
-    output, raw_image = _run(model, input_image, config)
+    # load the image
+    image_data = load_image(input_image)
+    raw_image = image_data
 
-    print('Output: (before post process)')
-    print(output)
+    # pre process for image
+    image_data = _pre_process(image_data, config.PRE_PROCESSOR, config.DATA_FORMAT)
+
+    # add the batch dimension
+    image_data = np.expand_dims(image_data, axis=0)
+
+    # run the model
+    output = _run(model, image_data, config)
+
+    logging.info('Output: (before post process)\n{}'.format(output))
 
     # pre process for output
     output = _post_process(output, config.POST_PROCESSOR)
 
-    print('Output: ')
-    print(output)
+    logging.info('Output: (after post process)\n{}'.format(output))
 
     # json output
     json_output = JsonOutput(
@@ -130,6 +148,63 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
         classes=config.CLASSES,
         image_size=config.IMAGE_SIZE,
         data_format=config.DATA_FORMAT,
+    )
+
+    image_from_json = ImageFromJson(
+        task=Tasks(config.TASK),
+        classes=config.CLASSES,
+        image_size=config.IMAGE_SIZE,
+    )
+
+    output_dir = "output"
+    outputs = output
+    raw_images = [raw_image]
+    image_files = [input_image]
+    json_obj = json_output(outputs, raw_images, image_files)
+    _save_json(output_dir, json_obj)
+    filename_images = image_from_json(json_obj, raw_images, image_files)
+    _save_images(output_dir, filename_images)
+
+
+def run_prediction_with_bench(input_image, model, config_file, max_percent_incorrect_values=0.1, trial=1):
+    if not input_image or not model or not config_file:
+        logger.error('Please check usage with --help option')
+        exit(1)
+    config = load_yaml(config_file)
+    logger.warn("trial: {}".format(trial))
+
+    # load the image
+    image_data = load_image(input_image)
+    raw_image = image_data
+
+    # pre process for image
+    image_data, bench_pre = _timerfunc(_pre_process, (image_data, config.PRE_PROCESSOR, config.DATA_FORMAT), trial)
+
+    # add the batch dimension
+    image_data = np.expand_dims(image_data, axis=0)
+
+    # run the model to inference
+    output, bench_inference = _timerfunc(_run, (model, image_data, config), trial)
+
+    logging.info('Output: (before post process)\n{}'.format(output))
+
+    # pre process for output
+    output, bench_post = _timerfunc(_post_process, (output, config.POST_PROCESSOR), trial)
+
+    logging.info('Output: (after post process)\n{}'.format(output))
+
+
+    # json output
+    json_output = JsonOutput(
+        task=Tasks(config.TASK),
+        classes=config.CLASSES,
+        image_size=config.IMAGE_SIZE,
+        data_format=config.DATA_FORMAT,
+        bench={
+            "pre": bench_pre / trial,
+            "post": bench_post / trial,
+            "inference": bench_inference / trial,
+        },
     )
 
     image_from_json = ImageFromJson(
@@ -172,15 +247,31 @@ def run_prediction(input_image, model, config_file, max_percent_incorrect_values
     type=click.Path(exists=True),
     help="Config file Path",
 )
-def main(input_image, model, config_file):
+@click.option(
+    "--bench",
+    help="Enable Benchmark",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--trial",
+    help="# of trial for Benchmark",
+    type=click.INT,
+    default=1,
+)
+def main(input_image, model, config_file, bench, trial):
     _check_deprecated_arguments()
-    run_prediction(input_image, model, config_file)
+    if bench is True:
+        logger.info("Beanchmark is triggered with {} times trial".format(trial))
+        run_prediction_with_bench(input_image, model, config_file, trial=trial)
+    else:
+        run_prediction(input_image, model, config_file)
 
 
 def _check_deprecated_arguments():
     argument_list = sys.argv
     if '-l' in argument_list:
-        print("Deprecated warning: -l is deprecated please use -m instead")
+        logging.info("Deprecated warning: -l is deprecated please use -m instead")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] Add --bench and --trial option in run.py (in output dir)
- [x] Change print to logger
- [x] Run bench with .so file
- [x] Run bench with .pb file (with install tensorflow)
- [x] ~Run bench with .elf file~

<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
I want performance benchmark for inference-side devices

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):
```
python run.py -m ../models/minimal_graph_with_shape.pb -c ../models/meta.yaml -i ../caltech101_classification_has_validation_20191010145425/export/save.ckpt-30/128x128/inference_test_data/raw_image.png --bench --trial=10
INFO:__main__:Beanchmark is triggered with 10 times trial
INFO:__main__:Function _pre_process took 0.001985342000000001 seconds to complete
INFO:__main__:Function _pre_process took 0.001781323999999973 seconds to complete
INFO:__main__:Function _pre_process took 0.0015847509999999954 seconds to complete
INFO:__main__:Function _pre_process took 0.0020573539999999557 seconds to complete
INFO:__main__:Function _pre_process took 0.0021465889999999765 seconds to complete
INFO:__main__:Function _pre_process took 0.0014984670000000033 seconds to complete
INFO:__main__:Function _pre_process took 0.0015263009999999522 seconds to complete
INFO:__main__:Function _pre_process took 0.002129837999999995 seconds to complete
INFO:__main__:Function _pre_process took 0.0018432219999999777 seconds to complete
INFO:__main__:Function _pre_process took 0.0017701199999999861 seconds to complete
INFO:__main__:Avg(func _pre_process): 0.0018323307999999817 sec.
INFO:__main__:Function _run took 1.2936168460000002 seconds to complete
INFO:__main__:Function _run took 0.186034539 seconds to complete
INFO:__main__:Function _run took 0.165938197 seconds to complete
INFO:__main__:Function _run took 0.16927644499999994 seconds to complete
INFO:__main__:Function _run took 0.181955125 seconds to complete
INFO:__main__:Function _run took 0.1702543460000001 seconds to complete
INFO:__main__:Function _run took 0.1659946790000002 seconds to complete
INFO:__main__:Function _run took 0.16076352299999952 seconds to complete
INFO:__main__:Function _run took 0.1720339179999999 seconds to complete
INFO:__main__:Function _run took 0.1715396349999998 seconds to complete
INFO:__main__:Avg(func _run): 0.28374072529999994 sec.
INFO:root:Output: (before post process)
[[0.1043328  0.10301837 0.10024849 0.09968052 0.09801209 0.09797116
0.09353667 0.10142121 0.09947895 0.10229976]]
INFO:__main__:Function _post_process took 0.0046468449999998995 seconds to complete
INFO:__main__:Function _post_process took 0.0013953019999997096 seconds to complete
INFO:__main__:Function _post_process took 0.0014312090000001554 seconds to complete
INFO:__main__:Function _post_process took 0.0013390870000002941 seconds to complete
INFO:__main__:Function _post_process took 0.0015897990000000028 seconds to complete
INFO:__main__:Function _post_process took 0.0015181779999999812 seconds to complete
INFO:__main__:Function _post_process took 0.001253987000000123 seconds to complete
INFO:__main__:Function _post_process took 0.0010709200000000862 seconds to complete
INFO:__main__:Function _post_process took 0.0014579610000002852 seconds to complete
INFO:__main__:Function _post_process took 0.0013487299999996871 seconds to complete
INFO:__main__:Avg(func _post_process): 0.0017052018000000223 sec.
INFO:root:Output: (after post process)
[[0.1043328  0.10301837 0.10024849 0.09968052 0.09801209 0.09797116
0.09353667 0.10142121 0.09947895 0.10229976]]
INFO:root:save json: output/output.json
INFO:root:save image: output/images/raw_image.png

```

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.