### PR TITLE
The debug binary now show how much memory it will try to allocate on the heap

### DIFF
--- a/dlk/python/dlk/templates/include/network.tpl.h
+++ b/dlk/python/dlk/templates/include/network.tpl.h
@@ -28,6 +28,7 @@ public:
     Network();
     ~Network();
 
+    int memory();
     bool init();
 
     int get_input_rank();

--- a/dlk/python/dlk/templates/mains/main.tpl.cpp
+++ b/dlk/python/dlk/templates/mains/main.tpl.cpp
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
 
   Measurement::Start("TotalInitTime");
   Network nn;
+  std::cout << "This network will try to allocate " << nn.memory() / 1024.0 / 1024.0 << " MB on the heap" << std::endl;
   bool initialized = nn.init();
   Measurement::Stop();
 

--- a/dlk/python/dlk/templates/src/network.tpl.cpp
+++ b/dlk/python/dlk/templates/src/network.tpl.cpp
@@ -168,6 +168,32 @@ Network::~Network()
 #endif
 }
 
+int Network::memory() {
+  int total_mem_bytes = 0;
+  {% for node in graph.non_variables -%}
+  {% if node.available_buffer == '' -%}
+  {% for out_k in node.output_ops.keys() -%}
+  {% if node.output_ops.keys()|length > 1 -%}
+  total_mem_bytes += sizeof({{ node.dtype.cpptype() }}) * ({{ node.view.size_in_words_as_cpp }}); // {{ node.name + '_' + out_k }}_raw
+  {% else -%}
+  total_mem_bytes += sizeof({{ node.dtype.cpptype() }}) * ({{ node.view.size_in_words_as_cpp }}); // {{ node.name }}_raw
+  {%- endif %}
+  {%- endfor %}
+  {% elif node.available_buffer != '' and node.output_ops.keys()|length > 1 -%}
+  {% for out_k in node.output_ops.keys() -%}
+  {% if out_k != node.output_ops.keys()|list|first -%}
+  total_mem_bytes += sizeof({{ node.dtype.cpptype() }}) * ({{ node.view.size_in_words_as_cpp }}); // {{ node.name + '_' + out_k }}_raw
+  {%- endif %}
+  {%- endfor %}
+  {%- endif %}
+  {%- endfor %}
+#if !defined RUN_ON_FPGA
+  total_mem_bytes += sizeof(QUANTIZED_PACKED) * max_device_input_elems;
+  total_mem_bytes += sizeof(BIN_CONV_OUTPUT) * max_device_output_elems;
+#endif
+  return total_mem_bytes;
+}
+
 bool Network::init()
 {
 


### PR DESCRIPTION

Currently there is no way of knowing how much memory a network model requires for activations on deployment.

## Motivation and Context
It is possible to know the required memory from the Tensorflow model but will not match with the actual required amount of memory due to buffer reuse and quantization. This PR will make the debug binary (`lm_xxx.elf`) to print a message that show how much memory will be allocated on the heap **before** calling `Network::init()`. This allows you to have an idea of how much memory will be used and, debug possibly related memory issues.

## Description
- Added a new method to `Network` class that returns the amount of memory in bytes.
- Use this method from `mains/main.cpp` and print how many megabytes will be required by the model.

## How has this been tested?
Tested with 2 of the provided examples:
- classification: lmnet_quantized_cifar10
- object detection: widerface_v5

## Screenshots (if appropriate):
For object detection this will show:
```
This network will try to allocate 10.2753 MB on the heap
-------------------------------------------------------------
Comparison: Default network test  succeeded!!!
-------------------------------------------------------------
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
