### PR TITLE
[WIP] Adding checker of hardware constrain for D2S

### DIFF
--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -2560,7 +2560,17 @@ class DepthToSpace(Operator):
         super().__init__(name, shape, dtype, input_ops, dimension_format=dimension_format)
 
     def _check_consistency(self) -> None:
+        """
+        This check the following constraints:
+            1. qunatized-packed data requires depth of input must be multiple of kernel_size^2 * 32
+        """
         super()._check_consistency()
+        if self.input_ops['input'].op_type == 'QTZ_linear_mid_tread_half' and \
+                self.input_ops['input'].channel % 128 != 0:
+            warnings.warn(warning_sign +
+                          f" Input channels need to be multiple of kernel_size^2 * 32 for "
+                          f"{self.name} of {self.op_type}, but got {self.input_ops['input'].channel}",
+                          stacklevel=2)
 
     @property
     def is_monotonic(self) -> bool:


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
This PR adds the checker for the hardware constrains when importing `depth to space` operator, the checking rule is following the discussion in issue #470.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Including the checking in consistency check in `operator.py`.
Warning will be displayed when the constrain is not satisfied.

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
