### PR TITLE
[WIP] Adding checker of hardware constrain for Conv

### DIFF
--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -1017,7 +1017,30 @@ class Conv(Operator):
         # if kernel shape is not assigned, estimate kernel shape from input W's shape
 
     def _check_consistency(self) -> None:
+        """
+        This check the following condition:
+            1. Kernel size must be 1x1 or 3x3.
+            2. Max input channel size allowed is 1024.
+            3. Input channel size is multiple of 32.
+        """
         super()._check_consistency()
+        if self.kernel_shape[0] not in (1, 3):
+            warnings.warn(warning_sign +
+                          f" Kernel size must be 1x1 or 3x3 but got "
+                          f"{self.kernel_shape[0]}x{self.kernel_shape[1]} for {self.name} of {self.op_type}",
+                          stacklevel=2)
+        if self.input_ops['X'].channel > 1024 or self.channel > 1024:
+            warnings.warn(warning_sign +
+                          f" Input or output channel size need be less than 1024, but got "
+                          f"input: {self.input_ops['X'].channel} and output: {self.channel} "
+                          f"for {self.name} of {self.op_type}",
+                          stacklevel=2)
+        if self.input_ops['X'].channel % 32 != 0:
+            warnings.warn(warning_sign +
+                          f" Input channel size need be multiple of 32, but got "
+                          f"{self.input_ops['X'].channel} for {self.name} of {self.op_type}",
+                          stacklevel=2)
+
         self._assert(len(self.shape) == self._num_dimensions + 2,
                      f'{self.name} has illegal shape {self.shape}')
         self._assert(len(self.kernel_shape) == self._num_dimensions,

--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -1018,7 +1018,7 @@ class Conv(Operator):
 
     def _check_consistency(self) -> None:
         """
-        This check the following condition:
+        This checks the following condition:
             1. Kernel size must be 1x1 or 3x3.
             2. Max input channel size allowed is 1024.
             3. Input channel size is multiple of 32.

--- a/dlk/python/dlk/core/operators.py
+++ b/dlk/python/dlk/core/operators.py
@@ -1024,14 +1024,14 @@ class Conv(Operator):
             3. Input channel size is multiple of 32.
         """
         super()._check_consistency()
-        if self.kernel_shape[0] not in (1, 3):
+        if self.kernel_shape[0] != self.kernel_shape[1] or self.kernel_shape[0] not in (1, 3):
             warnings.warn(warning_sign +
-                          f" Kernel size must be 1x1 or 3x3 but got "
+                          f" Kernel size needs to be 1x1 or 3x3 but got "
                           f"{self.kernel_shape[0]}x{self.kernel_shape[1]} for {self.name} of {self.op_type}",
                           stacklevel=2)
         if self.input_ops['X'].channel > 1024 or self.channel > 1024:
             warnings.warn(warning_sign +
-                          f" Input or output channel size need be less than 1024, but got "
+                          f" Input and output channel size need to be less than 1024, but got "
                           f"input: {self.input_ops['X'].channel} and output: {self.channel} "
                           f"for {self.name} of {self.op_type}",
                           stacklevel=2)


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->
This PR adds the checker for the hardware constrains when importing `Conv` operator, the checking rule is following the discussion in issue #124 

-  Kernel size must be 1x1 or 3x3.
-  Max input and output channel size allowed are 1024.
-  Input channel size is multiple of 32.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
