### PR TITLE
Use more proper DATA_DIR in conftest.py

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,7 +25,7 @@ def init_env():
 
     # TODO: Remove this setting after lmnet.environment has been refactored.
     envs = {
-        "DATA_DIR": blueoil_dir,
+        "DATA_DIR": os.path.join(blueoil_dir, "lmnet", "tests", "fixtures", "datasets"),
         "OUTPUT_DIR": train_output_dir.name,
         "_EXPERIMENT_DIR": os.path.join(train_output_dir.name, "{experiment_id}"),
         "_TENSORBOARD_DIR": os.path.join(train_output_dir.name, "{experiment_id}", "tensorboard"),

--- a/tests/fixtures/configs/caltech101_classification.yml
+++ b/tests/fixtures/configs/caltech101_classification.yml
@@ -5,7 +5,7 @@ network_name: LmnetV1Quantize
 
 dataset:
   format: Caltech101
-  train_path: ./lmnet/tests/fixtures/datasets/dummy_classification
+  train_path: dummy_classification
   test_path: 
 
 trainer:

--- a/tests/fixtures/configs/caltech101_classification_has_validation.yml
+++ b/tests/fixtures/configs/caltech101_classification_has_validation.yml
@@ -5,8 +5,8 @@ network_name: LmnetV1Quantize
 
 dataset:
   format: Caltech101
-  train_path: ./lmnet/tests/fixtures/datasets/dummy_classification
-  test_path: ./lmnet/tests/fixtures/datasets/dummy_classification
+  train_path: dummy_classification
+  test_path: dummy_classification
 
 trainer:
   batch_size: 1

--- a/tests/fixtures/configs/camvid_custom_semantic_segmentation.yml
+++ b/tests/fixtures/configs/camvid_custom_semantic_segmentation.yml
@@ -5,7 +5,7 @@ network_name: LmSegnetV1Quantize
 
 dataset:
   format: CamvidCustom
-  train_path: ./lmnet/tests/fixtures/datasets/camvid_custom
+  train_path: camvid_custom
   test_path: 
 
 trainer:

--- a/tests/fixtures/configs/camvid_custom_semantic_segmentation_has_validation.yml
+++ b/tests/fixtures/configs/camvid_custom_semantic_segmentation_has_validation.yml
@@ -5,8 +5,8 @@ network_name: LmSegnetV1Quantize
 
 dataset:
   format: CamvidCustom
-  train_path: ./lmnet/tests/fixtures/datasets/camvid_custom
-  test_path: ./lmnet/tests/fixtures/datasets/camvid_custom
+  train_path: camvid_custom
+  test_path: camvid_custom
 
 trainer:
   batch_size: 1

--- a/tests/fixtures/configs/delta_mark_classification.yml
+++ b/tests/fixtures/configs/delta_mark_classification.yml
@@ -5,7 +5,7 @@ network_name: LmnetV1Quantize
 
 dataset:
   format: DeLTA-Mark for Classification
-  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_train
+  train_path: custom_delta_mark_classification/for_train
   test_path: 
 
 trainer:

--- a/tests/fixtures/configs/delta_mark_classification_has_validation.yml
+++ b/tests/fixtures/configs/delta_mark_classification_has_validation.yml
@@ -5,8 +5,8 @@ network_name: LmnetV1Quantize
 
 dataset:
   format: DeLTA-Mark for Classification
-  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_train
-  test_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_validation
+  train_path: custom_delta_mark_classification/for_train
+  test_path: custom_delta_mark_classification/for_validation
 
 trainer:
   batch_size: 1

--- a/tests/fixtures/configs/delta_mark_object_detection.yml
+++ b/tests/fixtures/configs/delta_mark_object_detection.yml
@@ -5,7 +5,7 @@ network_name: LMFYoloQuantize
 
 dataset:
   format: DeLTA-Mark for Object Detection
-  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_train
+  train_path: custom_delta_mark_object_detection/for_train
   test_path: 
 
 trainer:

--- a/tests/fixtures/configs/delta_mark_object_detection_has_validation.yml
+++ b/tests/fixtures/configs/delta_mark_object_detection_has_validation.yml
@@ -5,8 +5,8 @@ network_name: LMFYoloQuantize
 
 dataset:
   format: DeLTA-Mark for Object Detection
-  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_train
-  test_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_validation
+  train_path: custom_delta_mark_object_detection/for_train
+  test_path: custom_delta_mark_object_detection/for_validation
 
 trainer:
   batch_size: 1

--- a/tests/fixtures/configs/make_yml_config.py
+++ b/tests/fixtures/configs/make_yml_config.py
@@ -65,29 +65,29 @@ dataset_formats = [
 ]
 
 dataset_train_paths = [
-    '  train_path: ./lmnet/tests/fixtures/datasets/dummy_classification\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/dummy_classification\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_train\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/camvid_custom\n',
-    '  train_path: ./lmnet/tests/fixtures/datasets/camvid_custom\n',
+    '  train_path: dummy_classification\n',
+    '  train_path: dummy_classification\n',
+    '  train_path: custom_delta_mark_classification/for_train\n',
+    '  train_path: custom_delta_mark_classification/for_train\n',
+    '  train_path: custom_delta_mark_object_detection/for_train\n',
+    '  train_path: custom_delta_mark_object_detection/for_train\n',
+    '  train_path: custom_open_images_v4_bounding_boxes/for_train\n',
+    '  train_path: custom_open_images_v4_bounding_boxes/for_train\n',
+    '  train_path: camvid_custom\n',
+    '  train_path: camvid_custom\n',
 ]
 
 dataset_test_paths = [
     '  test_path: \n',
-    '  test_path: ./lmnet/tests/fixtures/datasets/dummy_classification\n',
+    '  test_path: dummy_classification\n',
     '  test_path: \n',
-    '  test_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_classification/for_validation\n',
+    '  test_path: custom_delta_mark_classification/for_validation\n',
     '  test_path: \n',
-    '  test_path: ./lmnet/tests/fixtures/datasets/custom_delta_mark_object_detection/for_validation\n',
+    '  test_path: custom_delta_mark_object_detection/for_validation\n',
     '  test_path: \n',
-    '  test_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_validation\n',
+    '  test_path: custom_open_images_v4_bounding_boxes/for_validation\n',
     '  test_path: \n',
-    '  test_path: ./lmnet/tests/fixtures/datasets/camvid_custom\n',
+    '  test_path: camvid_custom\n',
 ]
 
 trainer_batch_sizes = [

--- a/tests/fixtures/configs/openimagesv4_object_detection.yml
+++ b/tests/fixtures/configs/openimagesv4_object_detection.yml
@@ -5,7 +5,7 @@ network_name: LMFYoloQuantize
 
 dataset:
   format: OpenImagesV4
-  train_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_train
+  train_path: custom_open_images_v4_bounding_boxes/for_train
   test_path: 
 
 trainer:

--- a/tests/fixtures/configs/openimagesv4_object_detection_has_validation.yml
+++ b/tests/fixtures/configs/openimagesv4_object_detection_has_validation.yml
@@ -5,8 +5,8 @@ network_name: LMFYoloQuantize
 
 dataset:
   format: OpenImagesV4
-  train_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_train
-  test_path: ./lmnet/tests/fixtures/datasets/custom_open_images_v4_bounding_boxes/for_validation
+  train_path: custom_open_images_v4_bounding_boxes/for_train
+  test_path: custom_open_images_v4_bounding_boxes/for_validation
 
 trainer:
   batch_size: 1


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

In `init_env()`, `DATA_DIR` has been set to `blueoil_dir`. It is not proper. Since all dataset loaders except those who inherits `StoragePathCustomizable` will be broken. (They don't deal with `train_path` and `test_path` in config file.)
This PR makes an ordinary dataset loader can be used in `e2e` tests.
https://github.com/blue-oil/blueoil/blob/b45d0806a7daf8bff4af10e258c1e0b9d008953b/tests/e2e/conftest.py#L27-L33

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
