### PR TITLE
fix dtype of resize preprocessor

### DIFF
--- a/lmnet/lmnet/pre_processor.py
+++ b/lmnet/lmnet/pre_processor.py
@@ -33,7 +33,7 @@ def resize(image, size=[256, 256]):
     if width == image.shape[1] and height == image.shape[0]:
         return image
 
-    image = PIL.Image.fromarray(image)
+    image = PIL.Image.fromarray(np.uint8(image))
 
     image = image.resize([width, height])
 


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Dtype of Input image at `resize` in `lmnet/lmnet/pre_processor.py` is unsafe.

I made a tfds by `lmnet/executor/build_tfds.py` and ran `lmnet/executor/train.py`.
But it didn't work at validation/test subset because the dtype of the dataset is float32 (the values are in 0.0 to 255.0) and `resize` in `lmnet/lmnet/pre_processor.py` is only allow uint8.  

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Added `np.uint8` to convert function.
(Other preprocessor and augmentors are already applied)

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
Only unit test

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
