### PR TITLE
Fix to use declared logger on lmnet/lmnet/utils/predict_output/writer.py

### DIFF
--- a/lmnet/lmnet/utils/predict_output/writer.py
+++ b/lmnet/lmnet/utils/predict_output/writer.py
@@ -56,7 +56,7 @@ def save_npy(dest, outputs, step):
 
     np.save(filepath, outputs)
 
-    logging.info("save npy: {}".format(filepath))
+    logger.info("save npy: {}".format(filepath))
 
 
 def save_json(dest, json, step):
@@ -80,7 +80,7 @@ def save_json(dest, json, step):
     with open(filepath, "w") as f:
         f.write(json)
 
-    logging.info("save json: {}".format(filepath))
+    logger.info("save json: {}".format(filepath))
 
 
 def save_materials(dest, materials, step):
@@ -104,4 +104,4 @@ def save_materials(dest, materials, step):
 
         content.save(filepath)
 
-        logging.info("save image: {}".format(filepath))
+        logger.info("save image: {}".format(filepath))


### PR DESCRIPTION
Related #682, #417 

In `lmnet/lmnet/utils/predict_output/writer.py`, declared `logger = logging.getLogger(__name__)` but not used for logging. We should use it instead of `logging` directly.