### PR TITLE
AddV2 to Add mapping (1.15.0 -> 1.14.0)

### DIFF
--- a/dlk/python/dlk/plugins/tf.py
+++ b/dlk/python/dlk/plugins/tf.py
@@ -83,6 +83,7 @@ DLK_OPERATOR_MAP: Dict[str, str] = {
     'FusedBatchNormV3': 'BatchNormalization',
     'AvgPool': 'AveragePool',
     'BiasAdd': 'Add',
+    'AddV2': 'Add',
     'ConcatV2': 'ConcatOnDepth',
     'GatherV2': 'Gather'
 }


### PR DESCRIPTION
Added the operator label "AddV2" for add operation as used by TF 1.15.0 in `DLK_OPERATOR_MAP`.

## Context
* This change fixes the issue of compiler (dlk) throwing an error while converting final quantized model to FPGA-compatible model, due to change in name of an operator as Tensorflow version has been updated.
* This PR is related to issue #715 

## Testing
* I have locally applied the change and compiled my QuantizedResnet model successfully for DE10-Nano.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
