### PR TITLE
Add a tool to program Cyclone V FPGA on de10nano board from userspace

### DIFF
--- a/dlk/hw/intel/de10_nano/reset_fpga/CMakeLists.txt
+++ b/dlk/hw/intel/de10_nano/reset_fpga/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+# set(TOOLCHAIN_NAME "linux_arm")
+set(TOOLCHAIN_NAME "linux-armv8a-hardfloat")
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/toolchain/${TOOLCHAIN_NAME}.cmake")
+
+project(progfpga CXX)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS YES)
+
+list(APPEND PROGFPGA_SRC
+    main.cpp
+)
+
+include_directories(./thirdparty/)
+include_directories(./include)
+add_executable(progfpga ${PROGFPGA_SRC})
+

--- a/dlk/hw/intel/de10_nano/reset_fpga/include/fpga_component.h
+++ b/dlk/hw/intel/de10_nano/reset_fpga/include/fpga_component.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "memdriver.h"
+
+class FPGAComponent
+{
+
+public:
+
+  FPGAComponent(uint32_t csr_base_address)
+    : start_reg (csr_base_address, 1, sizeof(uint32_t)),
+      done_reg  (csr_base_address + 0x10, 1, sizeof(uint32_t)),
+      mem_reg (csr_base_address + 0x18, 1, sizeof(uint32_t)),
+      size_reg  (csr_base_address + 0x20, 1, sizeof(uint32_t))
+  {}
+
+  void setup(uint32_t mem_address, uint32_t size)
+  {
+    mem_reg.Write(mem_address);
+    size_reg.Write(size);
+  }
+
+  void run()
+  {
+    start_reg.Write(0x1);
+  }
+
+  void wait()
+  {
+    volatile uint32_t done_flag = 0;
+    while (!(done_flag & 0x2)) {
+      done_reg.Read(done_flag);
+    }
+  }
+
+private:
+
+  MappedMem start_reg;
+  MappedMem done_reg;
+  MappedMem mem_reg;
+  MappedMem size_reg;
+};

--- a/dlk/hw/intel/de10_nano/reset_fpga/include/memdriver.h
+++ b/dlk/hw/intel/de10_nano/reset_fpga/include/memdriver.h
@@ -1,0 +1,128 @@
+#include <stdio.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+class MappedMem
+{
+public:
+  using memtype = volatile void;
+
+  MappedMem(unsigned long g_paddr,
+            uint32_t g_count,
+            uint32_t g_size)
+    : mem(NULL), aligned_size(0)
+  {
+    memtype* aligned_vaddr;
+    unsigned long aligned_paddr;
+
+    /* Align address to access size */
+    g_paddr &= ~(g_size - 1);
+
+    aligned_paddr = g_paddr & ~(4096 - 1);
+    aligned_size = g_paddr - aligned_paddr + (g_count * g_size);
+    aligned_size = (aligned_size + 4096 - 1) & ~(4096 - 1);
+
+    int fd = -1;
+    if ((fd = open("/dev/mem", O_RDWR, 0)) < 0)
+      return;
+
+    aligned_vaddr = mmap(NULL,
+                         aligned_size,
+                         PROT_READ | PROT_WRITE,
+                         MAP_SHARED,
+                         fd, aligned_paddr);
+
+    if (aligned_vaddr == NULL) {
+      printf("Error mapping address %x\n", aligned_paddr);
+      return;
+    }
+
+    mem = (memtype *)((uint32_t)aligned_vaddr + (uint32_t)(g_paddr - aligned_paddr));
+    close(fd);
+  }
+
+  ~MappedMem()
+  {
+    if(mem != NULL)
+      munmap((void*)mem, aligned_size);
+  }
+
+
+  template<typename T>
+  memtype Write(T data)
+  {
+    T *mem_ptr = (T *) mem;
+    *mem_ptr = data;
+  }
+
+  template<typename T>
+  bool Check(T data)
+  {
+    T *mem_ptr = (T *) mem;
+    return *mem_ptr == data;
+  }
+
+
+  template<typename T>
+  memtype Read(T &data)
+  {
+    T *mem_ptr = (T *) mem;
+    data = *mem_ptr;
+  }
+
+
+  template<typename T>
+  memtype Write(T *data, unsigned int size)
+  {
+    T *mem_ptr = (T *) mem;
+    for(unsigned int i = 0; i < size; i++)
+      *mem_ptr++ = data[i];
+  }
+
+
+  template<typename T>
+  bool Check(T *data, unsigned int size)
+  {
+    bool success = true;
+    T *mem_ptr = (T *) mem;
+
+    for(unsigned int i = 0; i < size; i++)
+    {
+      success &= (*mem_ptr++ == data[i]);
+      if(!success)
+        break;
+    }
+
+    return success;
+  }
+
+
+  template<typename T>
+  memtype Read(T *data, unsigned int size)
+  {
+    // volatile T* _data = data;
+    T *mem_ptr = (T *) mem;
+    for(unsigned int i = 0; i < size; i++)
+      data[i] = *mem_ptr++;
+  }
+
+
+  memtype* get()
+  {
+    return mem;
+  }
+
+
+private:
+  MappedMem();
+  MappedMem(const MappedMem &);
+  MappedMem& operator=(const MappedMem &);
+
+private:
+  memtype *mem;
+  uint32_t aligned_size;
+};
+
+

--- a/dlk/hw/intel/de10_nano/reset_fpga/main.cpp
+++ b/dlk/hw/intel/de10_nano/reset_fpga/main.cpp
@@ -1,0 +1,229 @@
+#include <iostream>
+#include <time.h>
+#include <sys/time.h>
+#include <stdint.h>
+#include <bitset>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+#include "memdriver.h"
+
+#define CLOCK_TYPE CLOCK_THREAD_CPUTIME_ID
+
+#define MGR_STAT_ADDR 0xFF706000
+#define MGR_STAT_OFFSET 0x0
+
+#define MGR_CTRL_ADDR 0xFF706000
+#define MGR_CTRL_OFFSET 0x4
+
+#define GPIO_PORTA_EOI_ADDR 0xFF706000
+#define GPIO_PORTA_EOI_OFFSET 0x84C
+
+#define MGR_DATA_ADDR 0xFFB90000
+#define MGR_DATA_OFFSET 0x0
+
+#define MGR_DCLCK_STAT_ADDR 0xFF706000
+#define MGR_DCLCK_STAT_OFFSET 0xC
+
+#define MGR_DCLCK_COUNT_ADDR 0xFF706000
+#define MGR_DCLCK_COUNT_OFFSET 0x8
+
+#define MGR_CTRL_CDRATIO_8_MASK_UP 0x000000C0
+#define MGR_CTRL_CFGWDTH_32_MASK_UP 0x00000200
+#define MGR_CTRL_NCE_0_MASK_DOWN ~0x00000002
+#define MGR_CTRL_EN_HPSCONF_MASK_UP 0x00000001
+#define MGR_CTRL_NCONFIGPULL_MASK_UP 0x00000004
+#define MGR_CTRL_NCONFIGPULL_MASK_DOWN ~0x00000004
+#define MGR_STAT_MODE_BITS 0x00000007
+#define MGR_GPIO_PORTA_EOI_NS_CLEAR 0x00000001
+#define MGR_CTRL_AXICFGEN_ENABLE 0x00000100
+#define MGR_CTRL_AXICFGEN_DISABLE ~0x00000100
+#define MGR_CTRL_EN_HPSCONF_MASK_DOWN ~0x00000001
+
+#define GPIO_EXT_PORTA_ADDR 0xFF706000
+#define GPIO_EXT_PORTA_OFFSET 0x850
+
+
+char* load_rbf(const char *filename, size_t *bytes_read)
+{
+  FILE *f = NULL;
+  f = fopen(filename, "rb");
+  if(f == NULL) {
+    fprintf(stderr, "Error: cannot open file %s\n", filename);
+    return NULL;
+  }
+
+  fseek(f, 0, SEEK_END);
+  size_t file_size = ftell (f);
+  rewind(f);
+
+  // load into buffer
+  char *buf = (char*) malloc(sizeof(char) * file_size + sizeof(uint32_t));
+  *bytes_read = fread(buf, sizeof(char), file_size, f);
+  fclose(f);
+
+  if (*bytes_read != file_size) {
+    fprintf(stderr, "Error while reading file %s (bytes read %d of %d)\n", filename, *bytes_read, file_size);
+    return NULL;
+  }
+
+  return buf;
+}
+
+
+
+int main(int argc, const char* argv[])
+{
+  if(argc != 2) {
+    std::cout << "Use: " << argv[0] << " <.rbf file>" << std::endl;
+    return 0;
+  }
+
+  // read the rbf
+  size_t bytes_read = 0;
+  const uint32_t *config_words =  (uint32_t *) load_rbf(argv[1], &bytes_read);
+  if(config_words == NULL) {
+    std::cout << "Error reading .rbf file" << std::endl;
+    return 0;
+  }
+
+  size_t word_size = sizeof(uint32_t);
+  uint32_t aligned_size(0);
+
+  MappedMem mgr_stat_reg(MGR_STAT_ADDR + MGR_STAT_OFFSET, 1, sizeof(uint32_t));
+  MappedMem mgr_ctrl_reg(MGR_CTRL_ADDR + MGR_CTRL_OFFSET, 1, sizeof(uint32_t));
+  MappedMem gpio_porta_eoi_reg(GPIO_PORTA_EOI_ADDR + GPIO_PORTA_EOI_OFFSET, 1, sizeof(uint32_t));
+  MappedMem mgr_data_reg(MGR_DATA_ADDR + MGR_DATA_OFFSET, 1, sizeof(uint32_t));
+  MappedMem gpio_ext_porta_reg(GPIO_EXT_PORTA_ADDR + GPIO_EXT_PORTA_OFFSET, 1, sizeof(uint32_t));
+  MappedMem dclk_stat_reg(MGR_DCLCK_STAT_ADDR + MGR_DCLCK_STAT_OFFSET, 1, sizeof(uint32_t));
+  MappedMem dclk_cnt_reg(MGR_DCLCK_COUNT_ADDR + MGR_DCLCK_COUNT_OFFSET, 1, sizeof(uint32_t));
+
+  // timming starts here
+  struct timespec ts;
+  clock_gettime (CLOCK_TYPE, &ts);
+  uint64_t start = uint64_t(ts.tv_sec * 1000000000 + ts.tv_nsec);
+
+  // stat
+  volatile uint32_t stat_reg = 0;
+  mgr_stat_reg.Read(stat_reg);
+
+  // ctrl
+  volatile uint32_t ctrl_reg = 0, cfg_ctrl_reg = 0;
+  mgr_ctrl_reg.Read(ctrl_reg);
+
+  cfg_ctrl_reg = ctrl_reg;
+
+  cfg_ctrl_reg |= MGR_CTRL_CDRATIO_8_MASK_UP;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  cfg_ctrl_reg |= MGR_CTRL_CFGWDTH_32_MASK_UP;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  cfg_ctrl_reg &= MGR_CTRL_NCE_0_MASK_DOWN;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  cfg_ctrl_reg |= MGR_CTRL_EN_HPSCONF_MASK_UP;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  cfg_ctrl_reg |= MGR_CTRL_NCONFIGPULL_MASK_UP;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  mgr_stat_reg.Read(stat_reg);
+
+  while((stat_reg & MGR_STAT_MODE_BITS) != 0x1)
+    mgr_stat_reg.Read(stat_reg);
+
+  std::cout << "In reset phase!" << std::endl;
+
+  cfg_ctrl_reg &= MGR_CTRL_NCONFIGPULL_MASK_DOWN;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  mgr_stat_reg.Read(stat_reg);
+
+  mgr_stat_reg.Read(stat_reg);
+  while(stat_reg & MGR_STAT_MODE_BITS != 0x2)
+    mgr_stat_reg.Read(stat_reg);
+
+  std::cout << "In configuration phase!" << std::endl << std::endl;
+
+  volatile uint32_t gpio_ns_clear = MGR_GPIO_PORTA_EOI_NS_CLEAR;
+  gpio_porta_eoi_reg.Write(gpio_ns_clear);
+
+  mgr_ctrl_reg.Read(ctrl_reg);
+  cfg_ctrl_reg = ctrl_reg;
+
+  cfg_ctrl_reg |= MGR_CTRL_AXICFGEN_ENABLE;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  std::cout << "In configuration phase: ns clear and axcfgen" << std::endl << std::endl;
+
+  size_t i = 0;
+  volatile uint32_t dummy_word = 0x00000123;
+
+  std::cout << "Writing configuration: " << bytes_read / 4 << " words" << std::endl;
+  while(bytes_read >= word_size)
+  {
+    mgr_data_reg.Write(config_words[i++] + 0);
+    bytes_read -= word_size;
+  }
+
+  volatile uint32_t sw = config_words[i++];
+  if(bytes_read == 3)
+    mgr_data_reg.Write(sw & 0x00ffffff);
+  else if(bytes_read == 2)
+    mgr_data_reg.Write(sw & 0x0000ffff);
+  else if(bytes_read == 1)
+    mgr_data_reg.Write(sw & 0x000000ff);
+  else
+    ;
+
+  std::cout << "Waiting for conf done and status" << std::endl << std::endl;
+
+  volatile uint32_t ext_porta_reg = 0;
+  gpio_ext_porta_reg.Read(ext_porta_reg);
+  while((ext_porta_reg & 0x3) != 0x3)
+    gpio_ext_porta_reg.Read(ext_porta_reg);
+
+  mgr_ctrl_reg.Read(ctrl_reg);
+  cfg_ctrl_reg = ctrl_reg;
+
+  cfg_ctrl_reg &= MGR_CTRL_AXICFGEN_DISABLE;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  volatile uint32_t dclck_done = 0x1;
+  dclk_stat_reg.Write(dclck_done);
+
+  volatile uint32_t dclk_cnt = 0x4;
+  dclk_cnt_reg.Write(dclk_cnt);
+
+  dclck_done = 0x0;
+  dclk_stat_reg.Read(dclck_done);
+  while((dclck_done & 0x1) != 0x1)
+    dclk_stat_reg.Read(dclck_done);
+
+  dclck_done = 0x1;
+  dclk_stat_reg.Write(dclck_done);
+
+  mgr_stat_reg.Read(stat_reg);
+  while(stat_reg & MGR_STAT_MODE_BITS != 0x4)
+    mgr_stat_reg.Read(stat_reg);
+
+  std::cout << "In user mode state!" << std::endl;
+  std::cout << "Stat: " << std::bitset<32>(stat_reg) << std::endl << std::endl;
+
+  mgr_ctrl_reg.Read(ctrl_reg);
+  cfg_ctrl_reg = ctrl_reg;
+  cfg_ctrl_reg &= MGR_CTRL_EN_HPSCONF_MASK_DOWN;
+  mgr_ctrl_reg.Write(cfg_ctrl_reg);
+
+  std::cout << "Configuration finished" << std::endl;
+
+  clock_gettime (CLOCK_TYPE, &ts);
+
+  // Show time
+  uint64_t elapsed_time_us = (uint64_t(ts.tv_sec * 1000000000 + ts.tv_nsec) - start) / 1000;
+  std::cout << "Time: " << elapsed_time_us << " us" << ", " << start << std::endl;
+
+  return 0;
+}

--- a/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux-armv8a-hardfloat.cmake
+++ b/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux-armv8a-hardfloat.cmake
@@ -1,0 +1,28 @@
+#
+# Please, if you want to use a specific toolchain and sysroot
+# define TOOLCHAIN_PATH and CMAKE_SYSROOT variables:
+#
+set(TOOLCHAIN_PATH "")
+set(CMAKE_SYSROOT "")
+set(AARCH32 ON)
+
+#
+# Cross-compiling for ARM
+#
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+if(NOT TOOLCHAIN_PATH)
+    set(TOOLCHAIN_BIN_PATH "")
+else()
+    set(TOOLCHAIN_BIN_PATH ${TOOLCHAIN_PATH}/bin/)
+endif()
+
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-g++-8)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-g++-8)
+set(CMAKE_CXX_COMPILER_AR ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-ar)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux_aarch64.cmake
+++ b/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux_aarch64.cmake
@@ -1,0 +1,28 @@
+#
+# Please, if you want to use a specific toolchain and sysroot
+# define TOOLCHAIN_PATH and CMAKE_SYSROOT variables:
+#
+set(TOOLCHAIN_PATH "")
+set(CMAKE_SYSROOT "")
+
+
+#
+# Cross-compiling for ARM
+#
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+if(NOT TOOLCHAIN_PATH)
+    set(TOOLCHAIN_BIN_PATH "")
+else()
+    set(TOOLCHAIN_BIN_PATH ${TOOLCHAIN_PATH}/bin/)
+endif()
+
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_BIN_PATH}aarch64-linux-gnu-g++)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_BIN_PATH}aarch64-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER_AR ${TOOLCHAIN_BIN_PATH}aarch64-linux-gnu-ar)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux_arm.cmake
+++ b/dlk/hw/intel/de10_nano/reset_fpga/toolchain/linux_arm.cmake
@@ -1,0 +1,28 @@
+#
+# Please, if you want to use a specific toolchain and sysroot
+# define TOOLCHAIN_PATH and CMAKE_SYSROOT variables:
+#
+set(TOOLCHAIN_PATH "")
+set(CMAKE_SYSROOT "")
+set(AARCH32 ON)
+
+#
+# Cross-compiling for ARM
+#
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+if(NOT TOOLCHAIN_PATH)
+    set(TOOLCHAIN_BIN_PATH "")
+else()
+    set(TOOLCHAIN_BIN_PATH ${TOOLCHAIN_PATH}/bin/)
+endif()
+
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-g++)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-g++)
+set(CMAKE_CXX_COMPILER_AR ${TOOLCHAIN_BIN_PATH}arm-linux-gnueabihf-ar)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
It adds a new tool to program Cyclone V FPGA found on de10 nano board.
From the command line, in Linux user space, this tool accepts an `.rbf` file and program the FPGA.
This tool has the same effect than rebooting the board.

## Motivation and Context
Useful for debugging and testing.

## Description
Is a new tool, nothing else was modified.
A binary is provided for easy use.

The procedure for configuring the FPGA is described in the Cyclone V  [configuration manual](https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/hb/cyclone-v/cv_5400A.pdf):

1. Set the cdratio and cfgwdth bits of the ctrl register in the FPGA manager registers (fpgamgrregs) to
match the characteristics of the configuration image. These settings are dependant on the MSEL pinsinput.

2. Set the nce bit of the ctrl register to 0 to enable HPS configuration.

3. Set the en bit of the ctrl registerto 1 to give the FPGA manager control of the configuration inputsignals.

4. Set the nconfigpull bit of the ctrl registerto 1 to pull down the nCONFIG pin and put the FPGA portion of the device into the reset phase.

5. Poll the mode bit of the stat register and wait until the FPGA enters the reset phase.

6. Set the nconfigpull bit of the ctrl register to 0 to release the FPGA from reset.

7. Read the mode bit of the stat register and wait until the FPGA enters the configuration phase.

8. Clear the interrupt bit of nSTATUS (ns) in the gpio interrupt register (fpgamgrregs.mon.gpio_porta_eoi).

9. Set the axicfgen bit of the ctrl register to 1 to enable sending configuration data to the FPGA.

10. Write the configuration image to the configuration data register (data) in the FPGA manager module configuration data registers (fpgamgrdata). You can also choose to use a DMA controller to transfer the configuration image from a peripheral device to the FPGA manager.

11. Use the fpgamgrregs.mon.gpio_ext_porta registers to monitor the CONF_DONE (cd) and nSTATUS (ns) bits.

12. Set the axicfgen bit of the ctrl register to 0 to disable configuration data on AXI slave.

13. Clear any previous DONE status bywriting a 1 to the dcntdone bit of the DCLK status register(dclkstat) to clear the completed status flag.

14. Send the DCLKs required by the FPGA to enter the initialization phase.

15. Poll the dcntdone bit of the DCLK status register (dclkstat) until it changes to 1, which indicates that all the DCLKs have been sent.

16. Write a 1 to the dcntdone bit of the DCLK status register to clear the completed status flag.

17. Read the mode bit of the stat register to wait for the FPGA to enter user mode.

18. Set the en bit of the ctrl register to 0 to allow the external pins to drive the configuration input signals.


## How has this been tested?
It is specific low level code for de10nano board. It has the single functionality of programming the FPGA chip and nothing else.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
