### PR TITLE
Fix pytype return for Uint16

### DIFF
--- a/dlk/python/dlk/core/data_types.py
+++ b/dlk/python/dlk/core/data_types.py
@@ -112,7 +112,7 @@ class Uint16(Primitive, int):
 
     @classmethod
     def nptype(cls):
-        return np.uint8
+        return np.uint16
 
 
 class Int32(Primitive, int):


### PR DESCRIPTION
Fixed a small typo in a function that returns the python data type for Uint16.

## Context
* Fixes potential overflow issues due to incorrect data type.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
