### PR TITLE
Ensure pool processes have closed

### DIFF
--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -58,13 +58,6 @@ def setup_dataset(config, subset, rank):
     return DatasetIterator(dataset, seed=rank, enable_prefetch=enable_prefetch)
 
 
-def close_dataset(dataset):
-    if dataset.enable_prefetch == True:
-        dataset.prefetcher.terminate = True
-        dataset.prefetcher.pool.close()
-        dataset.prefetcher.pool.join()
-
-
 def start_training(config):
     use_horovod = horovod_util.is_enabled()
     print("use_horovod:", use_horovod)
@@ -351,10 +344,10 @@ def start_training(config):
         if rank == 0:
             progbar.update(step + 1)
     # training loop end.
-    close_dataset(train_dataset)
-    close_dataset(validation_dataset)
+    train_dataset.close_dataset()
+    validation_dataset.close_dataset()
     if use_train_validation_saving:
-        close_dataset(train_validation_saving_dataset)
+        train_validation_saving_dataset.close_dataset()
     print("Done")
 
 

--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -58,6 +58,13 @@ def setup_dataset(config, subset, rank):
     return DatasetIterator(dataset, seed=rank, enable_prefetch=enable_prefetch)
 
 
+def close_dataset(dataset):
+    if dataset.enable_prefetch == True:
+        dataset.prefetcher.terminate = True
+        dataset.prefetcher.pool.close()
+        dataset.prefetcher.pool.join()
+
+
 def start_training(config):
     use_horovod = horovod_util.is_enabled()
     print("use_horovod:", use_horovod)
@@ -344,6 +351,10 @@ def start_training(config):
         if rank == 0:
             progbar.update(step + 1)
     # training loop end.
+    close_dataset(train_dataset)
+    close_dataset(validation_dataset)
+    if use_train_validation_saving:
+        close_dataset(train_validation_saving_dataset)
     print("Done")
 
 

--- a/lmnet/executor/train.py
+++ b/lmnet/executor/train.py
@@ -344,10 +344,10 @@ def start_training(config):
         if rank == 0:
             progbar.update(step + 1)
     # training loop end.
-    train_dataset.close_dataset()
-    validation_dataset.close_dataset()
+    train_dataset.close()
+    validation_dataset.close()
     if use_train_validation_saving:
-        train_validation_saving_dataset.close_dataset()
+        train_validation_saving_dataset.close()
     print("Done")
 
 

--- a/lmnet/lmnet/datasets/dataset_iterator.py
+++ b/lmnet/lmnet/datasets/dataset_iterator.py
@@ -306,6 +306,12 @@ class DatasetIterator:
         self.seed += 1
         return random_indices
 
+    def close_dataset(self):
+        if self.enable_prefetch:
+            self.prefetcher.terminate = True
+            self.prefetcher.pool.close()
+            self.prefetcher.pool.join()
+
 
 if __name__ == '__main__':
 

--- a/lmnet/lmnet/datasets/dataset_iterator.py
+++ b/lmnet/lmnet/datasets/dataset_iterator.py
@@ -306,7 +306,7 @@ class DatasetIterator:
         self.seed += 1
         return random_indices
 
-    def close_dataset(self):
+    def close(self):
         if self.enable_prefetch:
             self.prefetcher.terminate = True
             self.prefetcher.pool.close()


### PR DESCRIPTION
In the main training file, make sure pool processes have closed down after training has finished by manually shutting them down.

## Motivation and Context
This is to solve the bug described in issue https://github.com/blue-oil/blueoil/issues/725 where the training loop has finished but the program doesn't end. It is especially a concern when using time-costed services, if the program still runs after training has finished, it is a waste of costly resource.

## Description
A simple function is added, which accepts a dataset object, and terminates, closes and joins pools from the prefetcher of that dataset. This is only relevant if prefetch is being used, so first it checks if enable_prefetch is true.

The function is called at the end of training on each of the datasets: train, validation, and train_validation_saving (if there is one).

Honestly, I'm not sure why this fixes the problem, the dataset prefetcher should shut down own its own without it. But it doesn't in certain important cases.

## How has this been tested?
How to reproduce the bug is explained in issue https://github.com/blue-oil/blueoil/issues/725

To test that this fix does work, I ran training under the same settings, except with the code change that is in this pull request, and it runs fine, and fixes the bug.

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
