### PR TITLE
Split global.tpl.h into types.h and global.tpl.h

### DIFF
--- a/dlk/python/dlk/templates/include/global.tpl.h
+++ b/dlk/python/dlk/templates/include/global.tpl.h
@@ -20,45 +20,7 @@ limitations under the License.
 #include <inttypes.h>
 #include <limits>
 #include <stdlib.h>
-#include <type_traits>
-#include "func/impl/pop_count.h"
-
-#ifdef __cpp_lib_byte
-#include <cstddef>
-using BYTE = std::byte;
-#else
-enum class byte : unsigned char {};
-using BYTE = byte;
-#endif
-
-typedef uint32_t T_UINT;
-typedef int32_t  T_INT;
-typedef float    T_FLOAT;
-typedef uint8_t  T_UINT8;
-typedef int8_t   T_INT8;
-typedef uint16_t  T_UINT16;
-typedef int16_t   T_INT16;
-
-#define QUANTIZED_NOT_PACKED uint8_t
-
-template <typename pack_type>
-class QuantizedPacked {
- public:
-  using T = pack_type;
-  using base_t = std::remove_cv_t<T>;
-  static constexpr std::size_t BitCount = sizeof(pack_type) * CHAR_BIT;
-  QuantizedPacked() = default;
-  explicit QuantizedPacked(const T val) : val(val) {}
-  explicit operator base_t() const { return val; }
-  template <typename U, std::enable_if_t<std::is_same<base_t, std::remove_cv_t<U>>::value, int> = 0>
-  QuantizedPacked<T>& operator|=(const QuantizedPacked<U>& that) {
-    val |= that.val;
-    return *this;
-  }
-  base_t Raw() const { return val; }
- private:
-  T val;
-} __attribute__ ((packed));
+#include "types.h"
 
 #if defined RUN_ON_FPGA
   using QUANTIZED_PACKED = QuantizedPacked<volatile {{ params.default_qword_dtype.cpptype() }}>;
@@ -66,37 +28,6 @@ class QuantizedPacked {
   using QUANTIZED_PACKED = QuantizedPacked<{{ params.default_qword_dtype.cpptype() }}>;
 #endif
 using QUANTIZED_PACKED_KERNEL = QuantizedPacked<{{ params.default_qword_dtype.cpptype() }}>;
-template <typename T1, typename T2,
-    std::enable_if_t<std::is_same<std::remove_cv_t<T1>, std::remove_cv_t<T2>>::value, int> = 0>
-inline auto operator^(const QuantizedPacked<T1>& lhs, const QuantizedPacked<T2>& rhs) {
-  using packed_t = QuantizedPacked<std::remove_cv_t<T1>>;
-  return packed_t(lhs.Raw() ^ rhs.Raw());
-}
-template <typename pack_type>
-inline auto operator~(const QuantizedPacked<pack_type>& x) {
-  return QuantizedPacked<std::remove_cv_t<pack_type>>(~x.Raw());
-}
-template <typename pack_type>
-inline int pop_count(const QuantizedPacked<pack_type>& x) {
-  return dlk::impl::pop_count(x.Raw());
-}
-
-template <typename T>
-struct Base {
-  using type = T;
-};
-
-template <typename T>
-struct Base<QuantizedPacked<T>> {
-  using type = T;
-};
-
-#if defined RUN_ON_FPGA
-  typedef volatile T_INT16 BIN_CONV_OUTPUT;
-#else
-  typedef T_INT16 BIN_CONV_OUTPUT;
-#endif
-
 
 #define IP_CSR_ADDR 0xFF200000
 #define TH_IP_CSR_ADDR 0xFF200100
@@ -139,8 +70,6 @@ struct Base<QuantizedPacked<T>> {
 #define MAX_NBIT_KERNEL 1 // {{ params.max_nbit_qkernel }}
 #define MAX_IN_C 1024
 /********************************************************/
-
-typedef T_INT Quantized_t;
 
 void write_to_file(const char *filename, int id, volatile int32_t* data, int size);
 void write_to_file(const char *filename, int id, BIN_CONV_OUTPUT* data, int size);

--- a/dlk/python/dlk/templates/include/types.h
+++ b/dlk/python/dlk/templates/include/types.h
@@ -1,0 +1,90 @@
+/* Copyright 2018 The Blueoil Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <type_traits>
+#include "func/impl/pop_count.h"
+
+#ifdef __cpp_lib_byte
+#include <cstddef>
+using BYTE = std::byte;
+#else
+enum class byte : unsigned char {};
+using BYTE = byte;
+#endif
+
+typedef uint32_t T_UINT;
+typedef int32_t  T_INT;
+typedef float    T_FLOAT;
+typedef uint8_t  T_UINT8;
+typedef int8_t   T_INT8;
+typedef uint16_t  T_UINT16;
+typedef int16_t   T_INT16;
+
+#define QUANTIZED_NOT_PACKED uint8_t
+
+template <typename pack_type>
+class QuantizedPacked {
+ public:
+  using T = pack_type;
+  using base_t = std::remove_cv_t<T>;
+  static constexpr std::size_t BitCount = sizeof(pack_type) * CHAR_BIT;
+  QuantizedPacked() = default;
+  explicit QuantizedPacked(const T val) : val(val) {}
+  explicit operator base_t() const { return val; }
+  template <typename U, std::enable_if_t<std::is_same<base_t, std::remove_cv_t<U>>::value, int> = 0>
+  QuantizedPacked<T>& operator|=(const QuantizedPacked<U>& that) {
+    val |= that.val;
+    return *this;
+  }
+  base_t Raw() const { return val; }
+ private:
+  T val;
+} __attribute__ ((packed));
+
+template <typename T1, typename T2,
+    std::enable_if_t<std::is_same<std::remove_cv_t<T1>, std::remove_cv_t<T2>>::value, int> = 0>
+inline auto operator^(const QuantizedPacked<T1>& lhs, const QuantizedPacked<T2>& rhs) {
+  using packed_t = QuantizedPacked<std::remove_cv_t<T1>>;
+  return packed_t(lhs.Raw() ^ rhs.Raw());
+}
+template <typename pack_type>
+inline auto operator~(const QuantizedPacked<pack_type>& x) {
+  return QuantizedPacked<std::remove_cv_t<pack_type>>(~x.Raw());
+}
+template <typename pack_type>
+inline int pop_count(const QuantizedPacked<pack_type>& x) {
+  return dlk::impl::pop_count(x.Raw());
+}
+
+template <typename T>
+struct Base {
+  using type = T;
+};
+
+template <typename T>
+struct Base<QuantizedPacked<T>> {
+  using type = T;
+};
+
+#if defined RUN_ON_FPGA
+  typedef volatile T_INT16 BIN_CONV_OUTPUT;
+#else
+  typedef T_INT16 BIN_CONV_OUTPUT;
+#endif
+
+#endif // TYPES_H


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

part of #743 .

`types.h` doesn't use jinja template generator, so we can build statically code with this header.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

For testability of C++ codes, operators should not depend on jinja.
Most of type definitions don't depend on network which we use.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
