### PR TITLE
Add test for Dockerfile for GPU by running e2e test once

### DIFF
--- a/.buildkite/blueoil-pipeline.yml
+++ b/.buildkite/blueoil-pipeline.yml
@@ -1,4 +1,12 @@
 steps:
+  - command: "make test-gpu"
+    label: "GPU Test"
+    agents:
+    - "agent-type=gpu"
+    - "env=production"
+    timeout_in_minutes: "30"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: 'true'
   - command: "make test-classification"
     label: "classification"
     agents:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import tempfile
 
 import pytest
+import tensorflow as tf
 import yaml
 
 from blueoil.cmd.convert import convert
@@ -55,6 +56,11 @@ def init_env():
 
     train_output_dir.cleanup()
     predict_output_dir.cleanup()
+
+
+def is_gpu_available():
+    """Test TensorFlow can access a GPU"""
+    assert tf.config.experimental.list_physical_devices('GPU')
 
 
 def run_all_steps(dirs, config_file):

--- a/tests/e2e/test_gpu_classification.py
+++ b/tests/e2e/test_gpu_classification.py
@@ -1,0 +1,15 @@
+import pytest
+
+from conftest import is_gpu_available
+from conftest import run_all_steps
+
+
+@pytest.mark.parametrize(
+    "config_file", [
+        "caltech101_classification.yml",
+    ]
+)
+def test_gpu_classification(init_env, config_file):
+    """Run Blueoil test of classification"""
+    is_gpu_available()
+    run_all_steps(init_env, config_file)


### PR DESCRIPTION
Related #750
After #751, we don't have tests run on the GPU environment.
We have Dockerfile for GPU, so we need to test that Docker image, it is enough to run e2e test once, I think. So I added it.