### PR TITLE
Optimize concat on depth

### DIFF
--- a/dlk/python/dlk/templates/include/func/concat_on_depth.h
+++ b/dlk/python/dlk/templates/include/func/concat_on_depth.h
@@ -102,7 +102,11 @@ struct ConcatOnDepthImpl<QuantizedPacked<TQOut>, MemoryLayout::ChHWBCl, I, typen
     if (decltype(input)::layout == MemoryLayout::ChHWBCl) {
       const auto bytes = input.size() * sizeof(typename decltype(input)::base_t);
       const auto offset_words = offset_depth * out_height * out_width * bits;
-      std::memcpy(output.data() + offset_words, input.data(), bytes);
+      if (output.data() + offset_words != input.data()) {
+        std::memmove(output.data() + offset_words, input.data(), bytes);
+      } else {
+        // nothing to do
+      }
     } else {
       for (std::size_t d = 0; d < depth; ++d) {
         for (std::size_t h = 0; h < out_height; ++h) {


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

A part of #731 .
3x faster func_ConcatOnDepth on DE10-Nano.

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->

If memory layout of input and output is `ChHWBCl`, ConcatOnDepth is done by just sequential memory copy.
Furthermore, some of ConcatOnDepth are done by just pointer arithmetic, it will be enabled by another PR.

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
