### PR TITLE
Use Set instead of List for membership testing

### DIFF
--- a/blueoil/cmd/convert.py
+++ b/blueoil/cmd/convert.py
@@ -125,7 +125,7 @@ def make_all(project_dir, output_dir):
 
     # Make each target and move output files
     for target, output in make_list:
-        if target in ["lm_x86", "lm_x86_avx", "lm_arm", "lm_fpga", "lm_aarch64"]:
+        if target in {"lm_x86", "lm_x86_avx", "lm_arm", "lm_fpga", "lm_aarch64"}:
             os.environ["CXXFLAGS"] = cxxflags_cache + " -DFUNC_TIME_MEASUREMENT"
         else:
             os.environ["CXXFLAGS"] = cxxflags_cache

--- a/dlk/python/dlk/code_generater.py
+++ b/dlk/python/dlk/code_generater.py
@@ -133,7 +133,7 @@ class CodeGenerater(object):
 
             aliased = set()
             for prev_op in prev_ops:
-                if prev_op.op_type in ['Reshape', 'Split']:
+                if prev_op.op_type in {'Reshape', 'Split'}:
                     aliased.add(prev_op.name)
                     for i in prev_op.input_ops.values():
                         aliased.add(i.name)

--- a/dlk/python/dlk/plugins/tf.py
+++ b/dlk/python/dlk/plugins/tf.py
@@ -174,13 +174,13 @@ class Node(object):
         attrs_data = []
         if attr_name == 'padding' or attr_name == 'data_format':
             attrs_data.append(self.nd_.attr[attr_name].s)
-        elif attr_name in ['strides', 'ksize']:
+        elif attr_name in {'strides', 'ksize'}:
             attrs_data.append(self.nd_.attr[attr_name].list.i)
-        elif attr_name in ['epsilon', 'alpha']:
+        elif attr_name in {'epsilon', 'alpha'}:
             attrs_data.append(self.nd_.attr[attr_name].f)
         elif attr_name == 'is_training' or attr_name == 'use_cudnn_on_gpu':
             attrs_data.append(self.nd_.attr[attr_name].b)
-        elif attr_name in ['block_size', 'num_split']:
+        elif attr_name in {'block_size', 'num_split'}:
             attrs_data.append(self.nd_.attr[attr_name].i)
         else:
             raise ValueError(f'{self.op_type} {self.name} doesn\'t have the supported attribute.')
@@ -487,9 +487,9 @@ class Importer(object):
             op_type = self.convert_operator(node.op_type)
             if op_type == 'Conv':
                 return out_format, [out_format, _default_w_format, 'C']
-            elif op_type in ['QTZ_binary_mean_scaling', 'QTZ_binary_channel_wise_mean_scaling']:
+            elif op_type in {'QTZ_binary_mean_scaling', 'QTZ_binary_channel_wise_mean_scaling'}:
                 return _default_w_format, [_default_w_format]
-            elif op_type in ['QTZ_linear_mid_tread_half']:
+            elif op_type in {'QTZ_linear_mid_tread_half'}:
                 return out_format, [out_format, 'C', 'C']
             elif op_type == 'Pad':
                 return out_format, [out_format, 'Padding']

--- a/lmnet/executor/predict.py
+++ b/lmnet/executor/predict.py
@@ -55,7 +55,7 @@ def _get_images(filenames, pre_processor, data_format):
 def _all_image_files(directory):
     all_image_files = []
     for file_path in glob(os.path.join(directory, "*")):
-        if os.path.isfile(file_path) and imghdr.what(file_path) in ["jpeg", "png"]:
+        if os.path.isfile(file_path) and imghdr.what(file_path) in {"jpeg", "png"}:
             all_image_files.append(os.path.abspath(file_path))
 
     return all_image_files

--- a/lmnet/lmnet/data_augmentor.py
+++ b/lmnet/lmnet/data_augmentor.py
@@ -37,7 +37,7 @@ class Blur(data_processor.Processor):
 
     def __init__(self, value=(0, 1)):
 
-        if type(value) in [int, float]:
+        if type(value) in {int, float}:
             min_value = 0
             max_value = value
 
@@ -76,7 +76,7 @@ class Brightness(data_processor.Processor):
 
     def __init__(self, value=(0.75, 1.25)):
 
-        if type(value) in [int, float]:
+        if type(value) in {int, float}:
             min_value = value
             max_value = value
 
@@ -116,7 +116,7 @@ class Color(data_processor.Processor):
 
     def __init__(self, value=(0.75, 1.25)):
 
-        if type(value) in [int, float]:
+        if type(value) in {int, float}:
             min_value = value
             max_value = value
 
@@ -156,7 +156,7 @@ class Contrast(data_processor.Processor):
 
     def __init__(self, value=(0.75, 1.25)):
 
-        if type(value) in [int, float]:
+        if type(value) in {int, float}:
             min_value = value
             max_value = value
 
@@ -193,7 +193,7 @@ class Crop(data_processor.Processor):
 
     def __init__(self, size, resize=None):
 
-        if type(size) in [int, float]:
+        if type(size) in {int, float}:
             height = size
             width = size
 
@@ -213,7 +213,7 @@ class Crop(data_processor.Processor):
 
         if resize:
             self.is_resize = True
-            if type(resize) in [int, float]:
+            if type(resize) in {int, float}:
                 resize_height = resize
                 resize_width = resize
 
@@ -353,7 +353,7 @@ class Hue(data_processor.Processor):
 
     def __init__(self, value=(-10, 10)):
 
-        if type(value) in [int, float]:
+        if type(value) in {int, float}:
             min_value = - value
             max_value = value
 
@@ -724,7 +724,7 @@ class Rotate(data_processor.Processor):
 
     def __init__(self, angle_range=(0, 90)):
 
-        if type(angle_range) in [int, float]:
+        if type(angle_range) in {int, float}:
             min_angle = 0
             max_angle = angle_range
 

--- a/lmnet/lmnet/datasets/image_folder.py
+++ b/lmnet/lmnet/datasets/image_folder.py
@@ -77,7 +77,7 @@ class ImageFolderBase(StoragePathCustomizable, Base):
         for image_class in self.classes:
             image_dir = os.path.join(self.data_dir, image_class)
             for image_path in glob(os.path.join(image_dir, "*")):
-                if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]:
+                if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}:
                     all_image_files.append(image_path)
 
         return all_image_files

--- a/lmnet/lmnet/networks/base.py
+++ b/lmnet/lmnet/networks/base.py
@@ -50,7 +50,7 @@ class BaseNetwork(object):
             data_format='NHWC'
     ):
 
-        if data_format not in ["NCHW", "NHWC"]:
+        if data_format not in {"NCHW", "NHWC"}:
             raise RuntimeError("data format {} should be in ['NCHW', 'NHWC]'.".format(data_format))
 
         self.is_debug = is_debug

--- a/lmnet/lmnet/networks/classification/lm_resnet.py
+++ b/lmnet/lmnet/networks/classification/lm_resnet.py
@@ -73,7 +73,7 @@ class LmResnet(Base):
 
     def basicblock(self, x, out_ch, strides, training):
         """Basic building block of single residual function"""
-        in_ch = x.get_shape().as_list()[1 if self.data_format in ['NCHW', 'channels_first'] else 3]
+        in_ch = x.get_shape().as_list()[1 if self.data_format in {'NCHW', 'channels_first'} else 3]
         shortcut = x
 
         x = self._batch_norm(x, training)

--- a/lmnet/lmnet/networks/keypoint_detection/lm_single_pose_v1.py
+++ b/lmnet/lmnet/networks/keypoint_detection/lm_single_pose_v1.py
@@ -31,7 +31,7 @@ class LmSinglePoseV1(Base):
         self.custom_getter = None
         self.num_joints = 17
 
-        if stride not in [2, 4, 8, 16]:
+        if stride not in {2, 4, 8, 16}:
             raise ValueError("Only stride 2, 4, 8, 16 are supported.")
 
         self.stride = stride

--- a/lmnet/tests/lmnet_tests/datasets_tests/test_image_folder.py
+++ b/lmnet/tests/lmnet_tests/datasets_tests/test_image_folder.py
@@ -54,7 +54,7 @@ def test_image_folder():
 
     expected_image_dir = os.path.join(environment.DATA_DIR, Dummy.extend_dir)
     expected_paths = [image_path for image_path in glob(os.path.join(expected_image_dir, "**/*"))
-                      if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]]
+                      if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}]
 
     assert len(expected_paths) * (1-validation_size) == train_dataset.num_per_epoch
     assert len(expected_paths) * (validation_size) == validation_dataset.num_per_epoch
@@ -88,13 +88,13 @@ def test_has_validation_path():
 
     expected_train_image_dir = os.path.join(environment.DATA_DIR, DummyHasValidation.extend_dir)
     expected_train_paths = [image_path for image_path in glob(os.path.join(expected_train_image_dir, "**/*"))
-                            if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]]
+                            if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}]
 
     assert len(expected_train_paths) == train_dataset.num_per_epoch
 
     expected_validation_image_dir = os.path.join(environment.DATA_DIR, DummyHasValidation.validation_extend_dir)
     expected_validation_paths = [image_path for image_path in glob(os.path.join(expected_validation_image_dir, "**/*"))
-                                 if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]]
+                                 if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}]
 
     assert len(expected_validation_paths) == validation_dataset.num_per_epoch
 
@@ -113,13 +113,13 @@ def test_image_folder_onthefly():
 
     expected_train_image_dir = os.path.join(environment.DATA_DIR, DummyHasValidation.extend_dir)
     expected_train_paths = [image_path for image_path in glob(os.path.join(expected_train_image_dir, "**/*"))
-                            if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]]
+                            if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}]
 
     assert len(expected_train_paths) == train_dataset.num_per_epoch
 
     expected_validation_image_dir = os.path.join(environment.DATA_DIR, DummyHasValidation.validation_extend_dir)
     expected_validation_paths = [image_path for image_path in glob(os.path.join(expected_validation_image_dir, "**/*"))
-                                 if os.path.isfile(image_path) and imghdr.what(image_path) in ["jpeg", "png"]]
+                                 if os.path.isfile(image_path) and imghdr.what(image_path) in {"jpeg", "png"}]
 
     assert len(expected_validation_paths) == validation_dataset.num_per_epoch
 


### PR DESCRIPTION
In the case of membership testing(`if a in b`), it is better to use Set as `b` instead of List because using Set(hashable objects) is faster than List.
> A set object is an unordered collection of distinct hashable objects. Common uses include **membership testing**, ...

https://docs.python.org/3.6/library/stdtypes.html#set-types-set-frozenset


> Sets, however, are significantly faster than lists if you want to check if an item is contained within it. They can only contain unique items though.

https://stackoverflow.com/questions/2831212/python-sets-vs-lists

I think this is not so critical, but it is better to follow this principle. So I refactored codes.
Related: https://github.com/blue-oil/blueoil/pull/755#discussion_r371079463