### PR TITLE
Fix predict run.py degraded change

### DIFF
--- a/lmnet/lmnet/utils/predict_output/output.py
+++ b/lmnet/lmnet/utils/predict_output/output.py
@@ -40,7 +40,7 @@ class JsonOutput():
         self.classes = classes
         self.image_size = image_size
         self.data_format = data_format
-        self.bench = bench if bench else {}
+        self.bench = bench or {}
 
     def _classification(self, outputs, raw_images, image_files):
         assert outputs.shape == (len(image_files), len(self.classes))
@@ -177,6 +177,7 @@ class JsonOutput():
             "classes": [{"id": i, "name": class_name} for i, class_name in enumerate(self.classes)],
             "date": datetime.now().isoformat(),
             "results": [],
+            "benchmark": self.bench,
         }
 
         if self.task == Tasks.CLASSIFICATION:


### PR DESCRIPTION
<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
Inference example runner `run.py` got degraded in the change of the output.py

## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
`output.json` doesn't have the element `benchmark` due to the change of PR#688
I changed `lmnet/utils/output.py` to write the `benchmark` data

## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
<!--- If you have experiments report documents please link to here. -->
I run on raspberry-pi

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.