### PR TITLE
close the validation dataset used in evaluate

### DIFF
--- a/lmnet/executor/evaluate.py
+++ b/lmnet/executor/evaluate.py
@@ -164,6 +164,7 @@ def evaluate(config, restore_path, output_dir):
         'metrics': {k: float(v) for k, v in zip(list(metrics_ops_dict.keys()), metrics_values)},
     }
     save_json(output_dir, json.dumps(metrics_dict, indent=4,), metrics_dict["last_step"])
+    validation_dataset.close()
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))


### PR DESCRIPTION
after model evaluation is finished, close the validation dataset.
## Motivation and Context
A previous pull request https://github.com/blue-oil/blueoil/pull/726 closes the datasets used in training, so that when training finishes, the program will also stop running. (it is especially an issue if using costed computing resource). More details are also included in a previous issue https://github.com/blue-oil/blueoil/issues/725 for closing the datasets used in training.

However, the same problem will also occur when evaluating an already trained model. So, a similar change needs to be made for when evaluation is being run.
## Description
The validation dataset is closed by calling its close() method. This way of closing dataset is essentially the same as is already done in the training.
## How has this been tested?
Running evaluation on a trained model using ```python executor/evaluate.py``` in singularity container.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
