### PR TITLE
Fix documentation statement in 2.4.2

### DIFF
--- a/docs/tutorial/image_keypoint_detection.md
+++ b/docs/tutorial/image_keypoint_detection.md
@@ -65,7 +65,6 @@ apply quantization at the first layer?  no
 ```
 
 If configuration finishes, the configuration file is generated in the `my_config.yml` under config directory.
-It should be `keypoint_detection_demo.yml` if you use above example initialization.
 
 ## Train a network model
 


### PR DESCRIPTION
According to the tutorial the file name is based on an argument of 
`"blueoil init -o <config_file_path>"`

<!--- 👉👉👉 Provide a general summary of your changes. 👈👈👈 -->

## Motivation and Context
<!--- 💭💡💭 Why is this change required? What problem does it solve? 💭💡💭 -->
<!--- 🔗 If it fixes an open issue, please link to the issue here. 🔗 -->
I follow the tutorial but the configuration file is not` keypoint_detection_demo.yml `
## Description
<!--- 📝🎯📝 Describe your changes in detail. 📝🎯📝 -->
Remove an incorrect statement.
## How has this been tested?
<!--- 🙆👌🙆 Please describe in detail how you tested your changes. 🙆👌🙆 -->
<!--- Include details of your testing environment, details of your manual tests, snippet code or commands of your manual tests, table of experiments results metrics, tests ran to see how your change affects other areas of the code, etc. -->
```
cd docs
make html
```
<!--- If you have experiments report documents please link to here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- 🏁🎌🏁 What types of changes does your code introduce? Put an `x` in all the boxes that apply: 🏁🎌🏁 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Optimization (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- ✅✅✅ Go over all the following points, and put an `x` in all the boxes that apply. ✅✅✅ -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- TODO(wakisaka): After decide our code style, add this.
- [ ] My code follows the code style of this project.
-->
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
