### PR TITLE
Fix run.py import nnlib

### DIFF
--- a/output_template/python/run.py
+++ b/output_template/python/run.py
@@ -20,7 +20,7 @@ import os
 import sys
 import time
 
-from lmnet.nnlib import NNLib as NNLib
+from lmnet.nnlib import NNLib
 
 from blueoil.utils.image import load_image
 from blueoil.common import Tasks


### PR DESCRIPTION
## What this patch does to fix the issue.
This removes redundant code in run.py
## Link to any relevant issues or pull requests.
- Fix #855 