### PR TITLE
[WIP] Fix tensorflow-cpu dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 
 [options.extras_require]
 cpu =
-  tensorflow-cpu==1.15.2
+  tensorflow-cpu==1.15.0
 gpu =
   tensorflow-gpu==1.15.2
   gast==0.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 
 [options.extras_require]
 cpu =
-  tensorflow==1.15.2
+  tensorflow-cpu==1.15.2
 gpu =
   tensorflow-gpu==1.15.2
   gast==0.2.2


### PR DESCRIPTION
## What this patch does to fix the issue.

Fix #865 
`tensorflow-cpu` is correct package name, and it's don't have `1.15.2`. Current version is `1.15.0`

https://pypi.org/project/tensorflow-cpu/#history