### PR TITLE
Fix python files of output_template

### DIFF
--- a/output_template/python/blueoil/data_processor.py
+++ b/output_template/python/blueoil/data_processor.py
@@ -53,8 +53,8 @@ class Sequence:
         """
 
         # Avoid circular import
-        from lmnet.pre_processor import Resize, ResizeWithGtBoxes, ResizeWithMask, LetterBoxes
-        from lmnet.post_processor import FormatYoloV2
+        from blueoil.pre_processor import Resize, ResizeWithGtBoxes, ResizeWithMask, LetterBoxes
+        from blueoil.post_processor import FormatYoloV2
 
         for process in self.processors:
             class_list = (Resize, ResizeWithGtBoxes, ResizeWithMask, LetterBoxes)

--- a/output_template/python/blueoil/data_processor.py
+++ b/output_template/python/blueoil/data_processor.py
@@ -1,1 +1,88 @@
-../../../blueoil/data_processor.py
+# -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+import pprint
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+import six
+
+
+class Sequence:
+    """Sequence several processor together.
+
+    Args:
+        processors (List[Processor]): list of processor.
+
+    Examples:
+        | *Sequence([*
+        |     *FlipLeftRight(0.5),*
+        |     *Hue((-10, 10)),*
+        | *])*
+    """
+
+    def __init__(self, processors):
+        self.processors = processors
+
+    def __call__(self, **kwargs):
+        for processor in self.processors:
+            kwargs = processor(**kwargs)
+        return kwargs
+
+    def __repr__(self):
+        return pprint.saferepr(self.processors)
+
+    # TODO(wakisaka): Should create interface class to set image size for processor child class.
+    def set_image_size(self, image_size):
+        """Override processors image size
+
+        Args:
+            image_size(tuple): (height, width)
+        """
+
+        # Avoid circular import
+        from lmnet.pre_processor import Resize, ResizeWithGtBoxes, ResizeWithMask, LetterBoxes
+        from lmnet.post_processor import FormatYoloV2
+
+        for process in self.processors:
+            class_list = (Resize, ResizeWithGtBoxes, ResizeWithMask, LetterBoxes)
+            if isinstance(process, class_list):
+                process.size = image_size
+
+            if isinstance(process, FormatYoloV2):
+                process.image_size = image_size
+
+
+@six.add_metaclass(ABCMeta)
+class Processor():
+
+    @abstractmethod
+    def __call__(self, **kwargs):
+        """Call processor method for each a element of data.
+
+        Return image and labels etc.
+        """
+        return kwargs
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.__dict__)
+
+
+# TODO(wakisaka): move to somewhere.
+def binarize(labels, num_classes):
+    """Return numpy array binarized labels."""
+    targets = np.array(labels).reshape(-1)
+    one_hot = np.eye(num_classes)[targets]
+    return one_hot

--- a/output_template/python/blueoil/post_processor.py
+++ b/output_template/python/blueoil/post_processor.py
@@ -1,0 +1,1 @@
+../../../blueoil/post_processor.py


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix #852 

* Add `output_template/python/blueoil/post_processor.py` as a symbolic link
* Add `blueoil/utils/predict_output/__init__.py` to support python2 (DE10-Nano)
* Replace symlink of `data_processor.py` to the previous file (support python2) to revert a part of #832
  * https://github.com/blue-oil/blueoil/pull/871/commits/f88852d6f9fff54d8b5fc47e012f5f8d6401833c Just copied `data_processor.py` from [Before #832](https://github.com/blue-oil/blueoil/blob/bbe6c540d3ee4f80bed55c2c4150d4845c010d67/output_template/python/lmnet/data_processor.py)
  * https://github.com/blue-oil/blueoil/pull/871/commits/45091d287bc9c8021e24c1d8301698311e94ca00 Updated import path
## Link to any relevant issues or pull requests.
