### PR TITLE
Update prompt-toolkit requirement from 1.0.15 to 3.0.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
   numpy==1.17.4
   pandas==1.0.1
   Pillow==6.2.1
-  prompt_toolkit==1.0.15
+  prompt_toolkit==3.0.3
   pytablewriter==0.47.0
   PyYAML==4.2b4
   tensorflow-datasets==1.0.2


### PR DESCRIPTION
## What this patch does to fix the issue.
The current `prompt-toolkit` requirement is too old and not compatible with `ipython 7.11.1`.

This PR update prompt-toolkit` to 3.0.3, the current stable version and compatible with other required package.
https://pypi.org/project/prompt-toolkit/

## Link to any relevant issues or pull requests.
#771 