### PR TITLE
Fix LMBiSeNet inference (.elf) test error on x86 and DE10-Nano

### DIFF
--- a/blueoil/networks/segmentation/lm_bisenet.py
+++ b/blueoil/networks/segmentation/lm_bisenet.py
@@ -132,8 +132,10 @@ class LMBiSeNet(Base):
     def _context(self, x):
         with tf.compat.v1.variable_scope("context"):
             with tf.compat.v1.variable_scope("block_1"):
-                x = self._space_to_depth(name='s2d_1', inputs=x, block_size=8)
+                x = self._space_to_depth(name='s2d_1', inputs=x, block_size=4)
                 x = self._block('conv_1', x, 128, 1)
+                x = self._space_to_depth(name='s2d_2', inputs=x, block_size=2)
+                x = self._block('conv_2', x, 128, 1)
                 growth_rate = 32
                 bottleneck_rate = 2
                 x = densenet_group(
@@ -166,16 +168,16 @@ class LMBiSeNet(Base):
                 )
                 if self.use_attention_refinement and self.use_attention_refinement_16:
                     # attention module needs float inputs.
-                    x_down_16 = self._block('conv_2', x, 256, 1, activation=tf.nn.relu)
+                    x_down_16 = self._block('conv_2', x, 128, 1, activation=tf.nn.relu)
                     x = self.activation(x_down_16)
                 else:
-                    x_down_16 = self._block('conv_2', x, 256, 1)
+                    x_down_16 = self._block('conv_2', x, 128, 1)
                     x = x_down_16
 
             with tf.compat.v1.variable_scope("block_3"):
                 x = self._space_to_depth(name='s2d_3', inputs=x)
-                x = self._block('conv_1', x, 512, 1)
-                growth_rate = 256
+                x = self._block('conv_1', x, 256, 1)
+                growth_rate = 128
                 bottleneck_rate = 1
                 x = densenet_group(
                     "dense",
@@ -190,9 +192,9 @@ class LMBiSeNet(Base):
                 )
                 if self.use_attention_refinement or self.use_tail_gap:
                     # attention module and tail gap needs float inputs.
-                    x_down_32 = self._block('conv_2', x, 1024, 1, activation=tf.nn.relu)
+                    x_down_32 = self._block('conv_2', x, 512, 1, activation=tf.nn.relu)
                 else:
-                    x_down_32 = self._block('conv_2', x, 1024, 1)
+                    x_down_32 = self._block('conv_2', x, 512, 1)
 
             return x_down_32, x_down_16
 


### PR DESCRIPTION
## What this patch does to fix the issue.
- Edit the model by set all channel sizes within hardware restriction at 1024.

* It can pass the test but the result images are not good. (This will solve in other PR.)

## Link to any relevant issues or pull requests.
#830, #249 , #567 

## Tensor Board
### Learning Rate / Loss
<img width="659" alt="Screen Shot 2020-03-03 at 11 04 57" src="https://user-images.githubusercontent.com/6939637/75735796-e1733200-5d3e-11ea-8779-d066649bebcc.png">

### Metrics / IOU
<img width="693" alt="Screen Shot 2020-03-03 at 10 59 41" src="https://user-images.githubusercontent.com/6939637/75735664-8e00e400-5d3e-11ea-968d-6f6041d528c3.png">

### Images / Overlap Output Input
<img width="1106" alt="Screen Shot 2020-03-03 at 11 00 21" src="https://user-images.githubusercontent.com/6939637/75735659-893c3000-5d3e-11ea-9562-577ce673e4ed.png">

## Interence test
###  Run inference test on x86 Linux (Ubuntu 16.04)
```
$ ./models/lib/lm_x86.elf ../inference_test_data/000_images_placeholder\:0.npy ../inference_test_data/708_output\:0.npy

-------------------------------------------------------------
Comparison: Default network test  succeeded!!!
-------------------------------------------------------------
TotalInitTime 35231,  sum:35.231ms
TotalRunTime 1.07207e+06,  sum:1072.07ms
..Convolution 18247,1377,  sum:19.624ms
....kn2row-1x1 18244,1377,  sum:19.621ms
......matrix_multiplication 18242,1375,  sum:19.617ms
..BatchNorm 8966,277,  sum:9.243ms
..QTZ_linear_mid_tread_half 31401,  sum:31.401ms
....pack_input 9634,  sum:9.634ms
..ExtractImagePatches 132,23,17,2,161,25,19,  sum:0.379ms
..QuantizedConv2D 119548,30057,4538,9685,5468,9673,6464,9679,25243,4175,4246,4458,4256,4955,4260,5488,2044,3763,1007,4254,1443,4257,1859,4259,9242,2344,2099,270997,200955,242116,8149,  sum:1010.98ms
....Convert Tensor 131,30,13,5,13,5,14,5,10,5,2,4,2,4,2,5,3,1,1,0,1,0,1,0,2,2,3,200,45,23,21,  sum:0.553ms
....quantized-kn2row 119415,30025,4524,9678,5454,9666,6449,9673,25232,4170,4243,4453,4253,4950,4257,5482,2039,3761,1005,4253,1441,4256,1857,4258,9239,2341,2095,270797,200909,242092,8126,  sum:1010.39ms
......quantized_matrix_multiplication 112461,28176,3589,865,864,866,864,863,864,866,864,864,865,271,4503,864,863,863,866,863,864,865,866,863,864,270,5555,865,865,864,867,865,865,865,907,865,864,270,24494,3677,1564,1564,906,4007,1564,1566,904,4515,1564,1566,904,4931,1033,3535,892,4048,1323,4048,1753,4046,8771,1795,1033,1565,1620,1564,1564,1565,1564,1566,1564,1563,1565,1564,1565,1564,1564,1566,1563,1566,1564,1564,1973,1564,1565,1564,1564,1606,1564,1565,1564,1564,1566,1564,1565,1564,1564,1565,1564,1565,1564,1564,1565,1564,1565,1564,1563,1566,1564,1565,1564,1564,1565,1564,1565,1563,1564,1565,1564,1566,1564,1564,1606,1564,1593,1564,1564,1565,1572,1722,1564,1564,1566,1564,1565,1564,1564,1565,1564,1565,1564,1564,1565,1564,1565,1564,1564,1566,1564,1593,1564,1564,1566,1564,1566,1564,1564,1566,1564,1565,1563,1564,1566,1564,1564,1565,1564,1566,1564,1564,1583,1564,1606,1605,1564,1567,1564,1566,1564,1564,1566,1564,1566,1564,1564,1565,1564,1594,1595,1564,1632,1612,1750,1564,1602,1564,1564,1621,1564,1607,1564,1564,1651,1564,1635,1564,1564,1566,1564,1593,1564,1564,1565,1564,1565,1564,1564,1565,1564,1565,1564,1564,1660,1564,1566,1564,1563,1593,4700,4700,4698,4698,4698,4727,4793,4698,4698,4698,4700,4698,4698,4739,4823,4771,4727,4743,4726,4727,4729,4699,4699,4784,4753,4773,4726,4919,4840,4741,4701,4699,4708,4700,4699,4701,4740,4700,4700,4699,4700,1176,23121,23339,23150,23128,23194,23122,23185,23179,23161,23261,7223,8026,  sum:969.02ms
......ApplyThresholds 5561,1500,758,368,774,361,718,318,561,404,95,356,104,346,108,460,829,180,89,94,95,97,81,101,380,457,886,5473,2765,1744,  sum:26.063ms
......pack bits 1362,340,170,85,170,85,170,85,170,85,21,85,21,85,21,86,170,42,21,21,21,21,21,21,85,85,170,1368,1021,424,  sum:6.532ms
......Convert Tensor 27,7,4,3,4,3,4,3,4,2,0,2,0,2,1,2,4,1,0,0,0,0,0,0,2,2,4,56,21,7,88,  sum:0.253ms
......matrix_shift_add1 8,6,6,8,6,6,6,8,6,6,2,7,6,6,7,6,6,6,7,6,6,2,7,6,6,7,6,6,6,7,6,6,3,13,13,6,13,13,6,12,13,6,57,57,57,3,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,4,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,11,8,9,9,8,8,9,13,9,8,8,8,9,8,10,10,9,9,8,8,8,8,13,8,8,8,8,8,8,10,11,9,8,8,8,8,8,13,8,8,9,2,30,27,26,34,32,26,26,32,27,26,9,  sum:1.46ms
......matrix_shift_add2 20,21,21,21,21,21,21,21,22,21,5,19,21,21,21,21,23,21,21,21,21,5,19,21,21,21,21,21,21,21,21,21,5,20,21,11,20,21,11,20,21,11,27,27,27,15,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,22,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,20,21,21,22,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,22,21,21,21,24,22,21,33,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,20,21,21,21,21,21,21,15,33,37,37,37,37,38,38,37,37,38,37,38,37,38,38,38,37,38,37,37,38,37,38,37,37,38,37,37,38,37,37,37,38,38,37,37,38,37,37,37,35,6,48,50,50,50,51,50,50,50,50,50,12,  sum:6.393ms
..Memcpy 22,2,7,1,1,0,1,1,1,0,0,1,0,0,0,0,2,0,0,0,0,0,0,0,0,1,2,20,15,3,  sum:0.08ms
..func_ConcatOnDepth 8,7,9,1,2,3,1,4,1,5,10,  sum:0.051ms
..DepthToSpace 19,15,17,  sum:0.051ms
..QuantizedConv2D_ApplyScalingFactor 80,  sum:0.08ms
..ReLu 88,  sum:0.088ms
```

###  Run inference test onDE10-Nano
```
$ ./models/lib/lm_fpga.elf ../inference_test_data/000_images_placeholder\:0.npy ../inference_test_data/708_output\:0.npy

-------------------------------------------------------------
Comparison: Default network test  succeeded!!!
-------------------------------------------------------------
TotalInitTime 156282,  sum:156.282ms
TotalRunTime 240455,  sum:240.455ms
..Convolution 32536,4657,  sum:37.193ms
....kn2row-1x1 32505,4641,  sum:37.146ms
......matrix_multiplication 32489,4627,  sum:37.116ms
........matrix_transpose (row_major) 14,  sum:0.014ms
..BatchNorm 63160,1949,  sum:65.109ms
..QTZ_linear_mid_tread_half 46654,  sum:46.654ms
....pack_input 9161,  sum:9.161ms
..ExtractImagePatches 7777,1230,484,73,5456,1245,990,  sum:17.255ms
..QuantizedConv2D 10089,2859,728,608,786,613,900,604,1852,440,338,476,339,535,341,556,305,372,177,266,222,267,262,265,674,280,283,15271,9631,10935,1721,  sum:62.995ms
....Convert Tensor 2240,538,140,35,102,39,127,33,165,31,19,35,19,41,19,42,24,20,13,10,18,10,21,10,24,18,21,2228,525,472,249,  sum:7.288ms
....Sync UDMABuf Input 2269,865,287,152,349,153,406,151,468,152,83,167,84,185,84,200,89,89,50,32,67,33,83,32,101,83,85,2249,977,691,564,  sum:11.28ms
....Conv2D TCA 4936,1261,189,350,227,350,261,350,1108,187,193,206,193,231,193,244,83,208,70,182,93,182,115,182,481,111,77,10179,7645,9540,406,  sum:40.033ms
....Sync UDMABuf Output 596,166,85,49,83,49,81,49,85,49,24,48,24,57,24,49,84,34,24,24,24,23,23,23,48,48,80,584,452,202,477,  sum:3.668ms
..Memcpy 643,185,85,41,97,40,77,45,84,42,19,47,18,44,18,40,97,29,18,19,17,15,17,17,39,44,93,647,441,207,  sum:3.225ms
..func_ConcatOnDepth 207,241,293,59,78,75,21,23,32,167,451,  sum:1.647ms
..DepthToSpace 406,376,386,  sum:1.168ms
..QuantizedConv2D_ApplyScalingFactor 2163,  sum:2.163ms
..ReLu 1934,  sum:1.934ms
..Add 465,  sum:0.465ms
```
## Inference script 
###  Run inference script on x86 Linux (Ubuntu 16.04)
<https://gist.github.com/oatawa1/326e55bd42bed31275e2e50c8b5e15da>

### Run inference script onDE10-Nano
<https://gist.github.com/oatawa1/8f48df4f8f72d167f91a8584bc7b056e>

## Image
### Input image
![0006R0_f02040](https://user-images.githubusercontent.com/6939637/75734982-c3a4cd80-5d3c-11ea-9d8a-40fe78e9e9fc.jpg)
### Output x86 image
![0006R0_f02040_x86](https://user-images.githubusercontent.com/6939637/75735096-17171b80-5d3d-11ea-847f-4347727af1c6.png)
#### Output DE10-Nano image
![0006R0_f02040_fpga](https://user-images.githubusercontent.com/6939637/75735277-a1f81600-5d3d-11ea-8d83-839faed633d7.png)


