### PR TITLE
fix comparator for decreasing function of threshold skipping

### DIFF
--- a/blueoil/converter/templates/src/func/impl/generic/apply_thresholds.cpp
+++ b/blueoil/converter/templates/src/func/impl/generic/apply_thresholds.cpp
@@ -47,11 +47,11 @@ void ApplyThresholds(
         else
           new_d = 3;
       } else if (flag == -1) { // decreasing function
-        if (d > ts2)
+        if (d > ts0)
           new_d = 0;
         else if (d > ts1)
           new_d = 1;
-        else if (d > ts0)
+        else if (d > ts2)
           new_d = 2;
         else
           new_d = 3;


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix the comparator condition in `apply_thresholds.cpp` for threshold skipping. 
For decreasing case like this `(58,-76,-211, -1)`, where the `ts0` is 58, `ts1` is -76, and `ts2` is -211

## Link to any relevant issues or pull requests.
#247 