### PR TITLE
Fix output image results in Semantic Segmentation task from run.py

### DIFF
--- a/blueoil/utils/predict_output/output.py
+++ b/blueoil/utils/predict_output/output.py
@@ -118,18 +118,17 @@ class JsonOutput():
             }
 
             prediction = []
+            label = np.argmax(output, axis=2)
             for i, class_name in enumerate(self.classes):
-                img = output[:, :, i] * 255
-                img = PIL.Image.fromarray(img, mode="F")
-                img = img.convert("L")
+                img = np.zeros(label.shape[:2], dtype=np.uint8)
+                img[label == i] = 255
+                img = PIL.Image.fromarray(img, mode="L").convert('1')
                 img = img.resize((raw_image.shape[1], raw_image.shape[0]))
-
                 # base64 encode
                 buffered = BytesIO()
                 img.save(buffered, format="PNG")
                 encoded = base64.b64encode(buffered.getvalue())
                 encoded = encoded.decode("ascii")
-
                 prediction.append({
                     "class": {"id": i, "name": class_name},
                     "mask": encoded,

--- a/blueoil/utils/predict_output/output.py
+++ b/blueoil/utils/predict_output/output.py
@@ -124,11 +124,13 @@ class JsonOutput():
                 img[label == i] = 255
                 img = PIL.Image.fromarray(img, mode="L").convert('1')
                 img = img.resize((raw_image.shape[1], raw_image.shape[0]))
+
                 # base64 encode
                 buffered = BytesIO()
                 img.save(buffered, format="PNG")
                 encoded = base64.b64encode(buffered.getvalue())
                 encoded = encoded.decode("ascii")
+
                 prediction.append({
                     "class": {"id": i, "name": class_name},
                     "mask": encoded,

--- a/blueoil/utils/predict_output/output.py
+++ b/blueoil/utils/predict_output/output.py
@@ -122,7 +122,7 @@ class JsonOutput():
             for i, class_name in enumerate(self.classes):
                 img = np.zeros(label.shape[:2], dtype=np.uint8)
                 img[label == i] = 255
-                img = PIL.Image.fromarray(img, mode="L").convert('1')
+                img = PIL.Image.fromarray(img, mode="L")
                 img = img.resize((raw_image.shape[1], raw_image.shape[0]))
 
                 # base64 encode


### PR DESCRIPTION
## What this patch does to fix the issue.
Resolve the broken output image in Semantic Segmentation task from `run.py`

* Before 
![0006R0_f02040_x86](https://user-images.githubusercontent.com/6939637/75752140-712ed580-5d6b-11ea-9138-faa913a3911b.png)
* After
![0006R0_f02040](https://user-images.githubusercontent.com/6939637/75752145-73912f80-5d6b-11ea-900d-be71a5b3a685.png)

## Link to any relevant issues or pull requests.
#886 #830 

