### PR TITLE
tf_upgrade_v2 for blocks.py

### DIFF
--- a/blueoil/blocks.py
+++ b/blueoil/blocks.py
@@ -89,8 +89,8 @@ def lmnet_block(
         tf.Tensor: Output of current layer block.
     """
     with tf.compat.v1.variable_scope(name, custom_getter=custom_getter):
-        conv = tf.compat.v1.layers.conv2d(inputs, filters=filters, kernel_size=kernel_size, padding='SAME', use_bias=False,
-                                data_format=data_format)
+        conv = tf.compat.v1.layers.conv2d(inputs, filters=filters, kernel_size=kernel_size,
+                                          padding='SAME', use_bias=False, data_format=data_format)
 
         if use_batch_norm:
             axis = -1 if data_format == 'channels_last' else 1

--- a/blueoil/blocks.py
+++ b/blueoil/blocks.py
@@ -94,7 +94,7 @@ def lmnet_block(
 
         if use_batch_norm:
             axis = -1 if data_format == 'channels_last' else 1
-            batch_normed = tf.compat.v1.layers.batch_normalization(conv, axis=axis, training=is_training)
+            batch_normed = tf.keras.layers.BatchNormalization(axis=axis)(conv, training=is_training)
         else:
             batch_normed = conv
 

--- a/blueoil/blocks.py
+++ b/blueoil/blocks.py
@@ -94,7 +94,7 @@ def lmnet_block(
 
         if use_batch_norm:
             axis = -1 if data_format == 'channels_last' else 1
-            batch_normed = tf.keras.layers.BatchNormalization(axis=axis)(conv, training=is_training)
+            batch_normed = tf.compat.v1.layers.batch_normalization(conv, axis=axis, training=is_training)
         else:
             batch_normed = conv
 

--- a/blueoil/blocks.py
+++ b/blueoil/blocks.py
@@ -93,21 +93,8 @@ def lmnet_block(
                                 data_format=data_format)
 
         if use_batch_norm:
-            # TODO(wenhao) hw supports `tf.contrib.layers.batch_norm` currently. change it when supported.
-            # batch_normed = tf.layers.batch_normalization(conv,
-            #                                              momentum=0.99,
-            #                                              scale=True,
-            #                                              center=True,
-            #                                              training=is_training)
-            four_letter_data_format = 'NHWC' if data_format == 'channels_last' else 'NCHW'
-            batch_normed = tf.contrib.layers.batch_norm(conv,
-                                                        decay=0.99,
-                                                        scale=True,
-                                                        center=True,
-                                                        updates_collections=None,
-                                                        is_training=is_training,
-                                                        data_format=four_letter_data_format)
-
+            axis = -1 if data_format == 'channels_last' else 1
+            batch_normed = tf.compat.v1.layers.batch_normalization(conv, axis=axis, training=is_training)
         else:
             batch_normed = conv
 

--- a/blueoil/blocks.py
+++ b/blueoil/blocks.py
@@ -40,7 +40,7 @@ def darknet(name, inputs, filters, kernel_size, is_training=tf.constant(False), 
 
         conv = conv2d("conv", inputs, filters=filters, kernel_size=kernel_size,
                       activation=None, use_bias=False, data_format=channel_data_format,
-                      kernel_initializer=tf.contrib.layers.variance_scaling_initializer(),)  # he initializer
+                      kernel_initializer=tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0),)  # he initializer
 
         # TODO(wakisaka): Should be the same as darknet batch norm.
         # https://github.com/tensorflow/tensorflow/blob/r1.1/tensorflow/contrib/layers/python/layers/layers.py
@@ -89,7 +89,7 @@ def lmnet_block(
         tf.Tensor: Output of current layer block.
     """
     with tf.compat.v1.variable_scope(name, custom_getter=custom_getter):
-        conv = tf.layers.conv2d(inputs, filters=filters, kernel_size=kernel_size, padding='SAME', use_bias=False,
+        conv = tf.compat.v1.layers.conv2d(inputs, filters=filters, kernel_size=kernel_size, padding='SAME', use_bias=False,
                                 data_format=data_format)
 
         if use_batch_norm:
@@ -112,7 +112,7 @@ def lmnet_block(
             batch_normed = conv
 
         if use_bias:
-            bias = tf.get_variable('bias', shape=filters, initializer=tf.zeros_initializer)
+            bias = tf.compat.v1.get_variable('bias', shape=filters, initializer=tf.compat.v1.zeros_initializer)
             biased = batch_normed + bias
         else:
             biased = batch_normed
@@ -169,15 +169,15 @@ def conv_bn_act(
         raise ValueError("data format must be 'NCHW' or 'NHWC'. got {}.".format(data_format))
 
     with tf.compat.v1.variable_scope(name):
-        conved = tf.layers.conv2d(
+        conved = tf.compat.v1.layers.conv2d(
             inputs,
             filters=filters,
             kernel_size=kernel_size,
             padding='SAME',
             use_bias=False,
-            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(),  # he initializer
+            kernel_initializer=tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0),  # he initializer
             data_format=channel_data_format,
-            kernel_regularizer=tf.contrib.layers.l2_regularizer(weight_decay_rate),
+            kernel_regularizer=tf.keras.regularizers.l2(0.5 * (weight_decay_rate)),
         )
 
         batch_normed = tf.contrib.layers.batch_norm(

--- a/blueoil/networks/base.py
+++ b/blueoil/networks/base.py
@@ -163,20 +163,20 @@ class BaseNetwork(object):
            loss: loss function of this network.
 
         """
-        # TODO(wenhao): revert when support `tf.layers.batch_normalization`
-        # update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-        # with tf.control_dependencies(update_ops):
-        with tf.name_scope("train"):
-            if var_list == []:
-                var_list = tf.compat.v1.trainable_variables()
 
-            gradients = optimizer.compute_gradients(loss, var_list=var_list)
+        update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+        with tf.control_dependencies(update_ops):
+            with tf.name_scope("train"):
+                if var_list == []:
+                    var_list = tf.compat.v1.trainable_variables()
 
-            train_op = optimizer.apply_gradients(gradients, global_step=self.global_step)
+                gradients = optimizer.compute_gradients(loss, var_list=var_list)
 
-        # Add histograms for all gradients for every layer.
-        for grad, var in gradients:
-            if grad is not None:
-                tf.compat.v1.summary.histogram(var.op.name + "/gradients", grad)
+                train_op = optimizer.apply_gradients(gradients, global_step=self.global_step)
+
+                # Add histograms for all gradients for every layer.
+                for grad, var in gradients:
+                    if grad is not None:
+                        tf.compat.v1.summary.histogram(var.op.name + "/gradients", grad)
 
         return train_op

--- a/blueoil/networks/base.py
+++ b/blueoil/networks/base.py
@@ -165,18 +165,20 @@ class BaseNetwork(object):
         """
 
         update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-        with tf.control_dependencies(update_ops):
-            with tf.name_scope("train"):
-                if var_list == []:
-                    var_list = tf.compat.v1.trainable_variables()
 
-                gradients = optimizer.compute_gradients(loss, var_list=var_list)
+        with tf.name_scope("train"):
+            if var_list == []:
+                var_list = tf.compat.v1.trainable_variables()
 
-                train_op = optimizer.apply_gradients(gradients, global_step=self.global_step)
+            gradients = optimizer.compute_gradients(loss, var_list=var_list)
 
-                # Add histograms for all gradients for every layer.
-                for grad, var in gradients:
-                    if grad is not None:
-                        tf.compat.v1.summary.histogram(var.op.name + "/gradients", grad)
+            train_op = optimizer.apply_gradients(gradients, global_step=self.global_step)
+
+            train_op = tf.group([train_op, update_ops])
+
+            # Add histograms for all gradients for every layer.
+            for grad, var in gradients:
+                if grad is not None:
+                    tf.compat.v1.summary.histogram(var.op.name + "/gradients", grad)
 
         return train_op


### PR DESCRIPTION
## What this patch does to fix the issue.

I converted only the blueoil/block.py with the command line tool tf_upgrade_v2 to run on tensorflow2.

Since tf.contrib is not supported, I change it manually.

Here's what I did:
1. install newest tenosrflow (tensorflow-gpu==1.5.2)
2. Run the upgrade script tf_upgrade_v2
3. convert tf.contrib manually
4. Check the upgrade report for warnings and errors
5. Run test (make test)
6. Make sure there is no change in accuracy

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade

