### PR TITLE
convert tf2 for blueoil/generate_lmnet_config.py

### DIFF
--- a/blueoil/generate_lmnet_config.py
+++ b/blueoil/generate_lmnet_config.py
@@ -157,9 +157,9 @@ def _blueoil_to_lmnet(blueoil_config):
         keep_checkpoint_max = default_keep_checkpoint_max
 
     if optimizer == 'Adam':
-        optimizer_class = "tf.train.AdamOptimizer"
+        optimizer_class = "tf.compat.v1.train.AdamOptimizer"
     elif optimizer == 'Momentum':
-        optimizer_class = "tf.train.MomentumOptimizer"
+        optimizer_class = "tf.compat.v1.train.MomentumOptimizer"
     else:
         raise ValueError("not supported optimizer.")
 
@@ -173,9 +173,9 @@ def _blueoil_to_lmnet(blueoil_config):
     if learning_rate_schedule == "constant":
         learning_rate_func = None
     elif learning_rate_schedule == "cosine":
-        learning_rate_func = "tf.train.cosine_decay"
+        learning_rate_func = "tf.compat.v1.train.cosine_decay"
     else:
-        learning_rate_func = "tf.train.piecewise_constant"
+        learning_rate_func = "tf.compat.v1.train.piecewise_constant"
 
     if learning_rate_schedule == "constant":
         if optimizer == 'Momentum':


### PR DESCRIPTION
## What this patch does to fix the issue.
This patch makes blueoil/generate_lmnet_config.py compatible with tf2

generate_lmnet_config.py is module to create python config file.

The converter does not covert, since this module writes values to the tpl file and does not use TensorFlow functions directly (use the function name as string only) .

Since the converter does not covert,  I have to convert this module manually based on the example config conversion (https://github.com/blue-oil/blueoil/pull/899).

Here's what I did:
1 . I change the generating module manually.
2. Run test (make test)

The targets are 
* the value of NETWORK.OPTIMIZER_CLASS (e.g.  tf.train.AdamOptimizer )
* the value of NETWORK.LEARNING_RATE_FUNC (e.g. tf.train.piecewise_constant)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade

