### PR TITLE
Update blueoil tutorial document to match blueoil r 0.20

### DIFF
--- a/docs/tutorial/image_cls.md
+++ b/docs/tutorial/image_cls.md
@@ -68,7 +68,7 @@ Below is an example configuration.
   choose network:  LmnetV1Quantize
   choose dataset format:  Caltech101
   training dataset path:  /home/blueoil/cifar/train/
-  set validataion dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.)  yes
+  set validation dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.):  yes
   validataion dataset path:  /home/blueoil/cifar/test/
   batch size (integer):  64
   image size (integer x integer):  32x32
@@ -76,10 +76,10 @@ Below is an example configuration.
   select optimizer:  Momentum
   initial learning rate:  0.001
   choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay' -> learning rate decrease by 1/10 on {epochs}/3 and {epochs}*2/3 and {epochs}-1
-  enable data augmentation: Yes
+  enable data augmentation?  (Y/n):  Yes
   Please choose augmentors:  done (5 selections)
 -> select Brightness, Color, FlipLeftRight, Hue, SSDRandomCrop
-  apply quantization at the first layer?  no 
+  apply quantization at the first layer? (Y/n):  no 
 ```
 
 - Model name: (Any)

--- a/docs/tutorial/image_cls.md
+++ b/docs/tutorial/image_cls.md
@@ -51,11 +51,12 @@ The CIFAR-10 dataset consists of 60,000 32x32 color images split into 10 classe
 Generate your model configuration file interactively by running the `blueoil init` command.
 
     $ docker run --rm -it \
+        -v $(pwd)/cifar:/home/blueoil/cifar \
         -v $(pwd)/config:/home/blueoil/config \
         blueoil_$(id -un):{TAG} \
-        blueoil init -o config/my_config.yml
+        blueoil init -o config/cifar10_test.py
 
-The `{TAG}` value must be set to a value like `v0.15.0-15-gf493ec9` that can be obtained with the `docker images` command.
+The `{TAG}` value must be set to a value like `v0.20.0-11-gf1e07c8` that can be obtained with the `docker images` command.
 This value depends on your environment.
 
 Below is an example configuration.
@@ -98,7 +99,7 @@ Below is an example configuration.
 - Augmentors: (Random)
 - Quantization on the first layer: No
 
-If configuration finishes, the configuration file is generated in the `my_config.yml` under config directory.
+If configuration finishes, the configuration file is generated in the `cifar10_test.py` under config directory.
 
 ## Train a neural network
 
@@ -110,7 +111,7 @@ Train your model by running `blueoil train` with model configuration.
         -v $(pwd)/config:/home/blueoil/config \
         -v $(pwd)/saved:/home/blueoil/saved \
         blueoil_$(id -un):{TAG} \
-        blueoil train -c config/my_config.yml
+        blueoil train -c config/cifar10_test.py
 
 Just like init, set the value of `{TAG}` to the value obtained by `docker images`.
 Change the value of `CUDA_VISIBLE_DEVICES` according to your environment.

--- a/docs/tutorial/image_det.md
+++ b/docs/tutorial/image_det.md
@@ -43,11 +43,11 @@ Below is an example of initialization.
 ```
 #### Generate config ####
 your model name ():  objectdetection
-choose task type  object_detection
-choose network  LMFYoloQuantize
-choose dataset format  OpenImagesV4
+choose task type:  object_detection
+choose network:  LMFYoloQuantize
+choose dataset format:  OpenImagesV4
 training dataset path:  /home/blueoil/openimages_face/
-set validataion dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.)  no
+set validation dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.):  yes
 validation dataset path:  /home/blueoil/openimages_face/
 batch size (integer):  16
 image size (integer x integer):  224x224
@@ -55,10 +55,10 @@ how many epochs do you run training (integer):  1000
 select optimizer:  Adam
 initial learning rate:  0.001
 choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay' -> learning rate decrease by 1/10 on {epochs}/3 and {epochs}*2/3 and {epochs}-1
-enable data augmentation?  Yes
+enable data augmentation?  (Y/n):  Yes
 Please choose augmentors:  done (5 selections)
 -> select Brightness, Color, FlipLeftRight, Hue, SSDRandomCrop
-apply quantization at the first layer?  no
+apply quantization at the first layer? (Y/n):  no
 ```
 
 If configuration finishes, the configuration file is generated in the `objectdetection.py` under config directory.

--- a/docs/tutorial/image_det.md
+++ b/docs/tutorial/image_det.md
@@ -30,11 +30,12 @@ This dataset consists of 2866 Human Face images and 5170 annotation boxes.
 Generate your model configuration file interactively by running the `blueoil init` command.
 
     $ docker run --rm -it \
+	    -v $(pwd)/openimages_face:/home/blueoil/openimages_face \
 	    -v $(pwd)/config:/home/blueoil/config \
 	    blueoil_$(id -un):{TAG} \
-	    blueoil init -o config/my_config.yml
+	    blueoil init -o config/objectdetection.py
 
-The `{TAG}` value must be set to a value like `v0.15.0-15-gf493ec9` that can be obtained with the `docker images` command.
+The `{TAG}` value must be set to a value like `v0.20.0-11-gf1e07c8` that can be obtained with the `docker images` command.
 This value depends on your environment.
 
 Below is an example of initialization.
@@ -60,7 +61,7 @@ Please choose augmentors:  done (5 selections)
 apply quantization at the first layer?  no
 ```
 
-If configuration finishes, the configuration file is generated in the `my_config.yml` under config directory.
+If configuration finishes, the configuration file is generated in the `objectdetection.py` under config directory.
 
 ## Train a network model
 
@@ -72,7 +73,7 @@ Train your model by running `blueoil train` with a model configuration.
 	    -v $(pwd)/config:/home/blueoil/config \
 	    -v $(pwd)/saved:/home/blueoil/saved \
 	    blueoil_$(id -un):{TAG} \
-	    blueoil train -c config/my_config.yml
+	    blueoil train -c config/objectdetection.py
 
 Just like init, set the value of `{TAG}` to the value obtained by `docker images`.
 Change the value of `CUDA_VISIBLE_DEVICES` according to your environment.

--- a/docs/tutorial/image_keypoint_detection.md
+++ b/docs/tutorial/image_keypoint_detection.md
@@ -37,22 +37,22 @@ Below is an example of initialization.
 ```
 #### Generate config ####
 your model name ():  keypoint_detection_demo
-choose task type  keypoint_detection
-choose network  LmSinglePoseV1Quantize
-choose dataset format  Mscoco for Single-Person Pose Estimation
+choose task type:  keypoint_detection
+choose network:  LmSinglePoseV1Quantize
+choose dataset format:  Mscoco for Single-Person Pose Estimation
 training dataset path:  /home/blueoil/MSCOCO_2017/
-set validation dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.)  yes
+set validation dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.):  yes
 validation dataset path:  /home/blueoil/MSCOCO_2017/
 batch size (integer):  4
 image size (integer x integer):  160x160
 how many epochs do you run training (integer):  100
 select optimizer:  Adam
 initial learning rate:  0.001
-choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay-with-warmup' -> warmup learning rate 1/1000 in first epoch, then train the same way as '3-step-d
-enable data augmentation?  Yes
+choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay-with-warmup' -> warmup learning rate 1/1000 in first epoch, then train the same way as '3-step-decay'
+enable data augmentation? (Y/n):  Yes
 Please choose augmentors:  done (6 selections)
 -> select Blue, Brightness, Color, Contrast, FlipLeftRight, Hue
-apply quantization at the first layer?  no
+apply quantization at the first layer? (Y/n):  no
 ```
 
 If configuration finishes, the configuration file is generated in the `keypoint_detection_demo.py` under config directory.

--- a/docs/tutorial/image_keypoint_detection.md
+++ b/docs/tutorial/image_keypoint_detection.md
@@ -24,9 +24,13 @@ Note: Below instructions assume your current path is blueoil root path and the M
 Generate your model configuration file interactively by running the `blueoil init` command.
 
     $ docker run --rm -it \
+        -v /storage/dataset/MSCOCO_2017:/home/blueoil/MSCOCO_2017 \
         -v $(pwd)/config:/home/blueoil/config \
         blueoil_$(id -un):{TAG} \
-        blueoil init -o config/my_config.yml
+        blueoil init -o config/keypoint_detection_demo.py
+
+The `{TAG}` value must be set to a value like `v0.20.0-11-gf1e07c8` that can be obtained with the `docker images` command.
+This value depends on your environment.
 
 Below is an example of initialization.
 
@@ -47,10 +51,11 @@ initial learning rate:  0.001
 choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay-with-warmup' -> warmup learning rate 1/1000 in first epoch, then train the same way as '3-step-d
 enable data augmentation?  Yes
 Please choose augmentors:  done (6 selections)
+-> select Blue, Brightness, Color, Contrast, FlipLeftRight, Hue
 apply quantization at the first layer?  no
 ```
 
-If configuration finishes, the configuration file is generated in the `my_config.yml` under config directory.
+If configuration finishes, the configuration file is generated in the `keypoint_detection_demo.py` under config directory.
 
 ## Train a network model
 
@@ -64,7 +69,7 @@ Train your model by running `blueoil train` with a model configuration.
         -v $(pwd)/config:/home/blueoil/config \
         -v $(pwd)/saved:/home/blueoil/saved \
         blueoil_$(id -un):{TAG} \
-        blueoil train -c config/my_config.yml
+        blueoil train -c config/keypoint_detection_demo.py
 
 Just like init, set the value of `{TAG}` to the value obtained by `docker images`.
 Change the value of `CUDA_VISIBLE_DEVICES` according to your environment.

--- a/docs/tutorial/image_seg.md
+++ b/docs/tutorial/image_seg.md
@@ -72,11 +72,11 @@ Below is an example of initialization.
 ```
 #### Generate config ####
 your model name ():  camvid
-choose task type  semantic_segmentation
-choose network  LmSegnetV1Quantize
-choose dataset format  CamvidCustom
+choose task type:  semantic_segmentation
+choose network:  LmSegnetV1Quantize
+choose dataset format:  CamvidCustom
 training dataset path:  /home/blueoil/CamVid/
-set validataion dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.)  yes
+set validation dataset? (if answer no, the dataset will be separated for training and validation by 9:1 ratio.):  yes
 test dataset path:  /home/blueoil/CamVid/
 batch size (integer):  8
 image size (integer x integer):  360x480
@@ -84,10 +84,10 @@ how many epochs do you run training (integer):  1000
 choose optimizer: Adam
 initial learning rate:  0.001
 choose learning rate schedule ({epochs} is the number of training epochs you entered before):  '3-step-decay' -> learning rate decrease by 1/10 on {epochs}/3 and {epochs}*2/3 and {epochs}-1
-enable data augmentation?  Yes
+enable data augmentation?  (Y/n):  Yes
 Please choose augmentors:  done (5 selections)
 -> select Brightness, Color, Contrast, FlipLeftRight, Hue
-apply quantization at the first layer?  no
+apply quantization at the first layer? (Y/n):  no
 ```
 
 If configuration finishes, the configuration file is generated in the `camvid.py` under config directory.

--- a/docs/tutorial/image_seg.md
+++ b/docs/tutorial/image_seg.md
@@ -57,11 +57,17 @@ CamVid dataset consists of 360x480 color images in 12 classes. There are 367 tr
 Generate your model configuration file interactively by running the `blueoil init` command.
 
     $ docker run --rm -it \
+        -v $(pwd)/CamVid:/home/blueoil/CamVid \
 	    -v $(pwd)/config:/home/blueoil/config \
 	    blueoil_$(id -un):{TAG} \
-	    blueoil init -o config/my_config.yml
+	    blueoil init -o config/camvid.py
 
-This is an example of the initialization procedure.
+
+The `{TAG}` value must be set to a value like `v0.20.0-11-gf1e07c8` that can be obtained with the `docker images` command.
+This value depends on your environment.
+
+Below is an example of initialization.
+
 
 ```
 #### Generate config ####
@@ -84,7 +90,7 @@ Please choose augmentors:  done (5 selections)
 apply quantization at the first layer?  no
 ```
 
-If configuration finishes, the configuration file is generated in the `my_config.yml` under config directory.
+If configuration finishes, the configuration file is generated in the `camvid.py` under config directory.
 
 ## Train a network model
 
@@ -96,7 +102,7 @@ Train your model by running `blueoil train` command with model configuration.
 	    -v $(pwd)/config:/home/blueoil/config \
 	    -v $(pwd)/saved:/home/blueoil/saved \
 	    blueoil_$(id -un):{TAG} \
-	    blueoil train -c config/my_config.yml
+	    blueoil train -c config/camvid.py
 
 Just like init, set the value of `{TAG}` to the value obtained by `docker images`.
 Change the value of `CUDA_VISIBLE_DEVICES` according to your environment.


### PR DESCRIPTION
## What this patch does to fix the issue.
Update blueoil tutorial document to match blueoil r 0.20
- Add dataset path in blueoil init, now the dataset is used in initialization process.
- Update configuration file extension from .yml to .py as well as update the configuration file name to make it less confusing
- Update the {TAG} to v0.20.0 to make sure that it's compatible from v0.20.0

Misc
- Add selection of augmentation in keypoint detection
- Update minor text for consistency

## Link to any relevant issues or pull requests.
#897 #113 ?