### PR TITLE
Remove PYTHONPATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,3 @@ services:
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
       - DATA_DIR=/home/blueoil/dataset
       - OUTPUT_DIR=/home/blueoil/saved
-      - PYTHONPATH=/home/blueoil:/home/blueoil/lmnet:/home/blueoil/dlk/python/dlk


### PR DESCRIPTION
## What this patch does to fix the issue.
`PYTHONPATH` for docker-compose is no longer needed.

## Link to any relevant issues or pull requests.
