### PR TITLE
Apply tf_upgrade_v2 for utils

### DIFF
--- a/blueoil/utils/executor.py
+++ b/blueoil/utils/executor.py
@@ -88,7 +88,7 @@ def search_restore_filename(checkpoints_dir):
 
 
 def convert_variables_to_constants(sess, output_node_names=["output"]):
-    minimal_graph_def = tf.graph_util.convert_variables_to_constants(
+    minimal_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
         sess,
         sess.graph.as_graph_def(add_shapes=True),
         output_node_names,
@@ -114,7 +114,7 @@ def prepare_metrics(metrics_ops_dict):
         metrics_placeholders: list of metrics placeholder.
 
     """
-    with tf.name_scope("metrics"):
+    with tf.compat.v1.name_scope("metrics"):
         metrics_placeholders = []
         metrics_summaries = []
         for (metrics_key, metrics_op) in metrics_ops_dict.items():
@@ -125,6 +125,6 @@ def prepare_metrics(metrics_ops_dict):
             metrics_placeholders.append(metrics_placeholder)
             metrics_summaries.append(summary)
 
-        metrics_summary_op = tf.summary.merge(metrics_summaries)
+        metrics_summary_op = tf.compat.v1.summary.merge(metrics_summaries)
 
     return metrics_summary_op, metrics_placeholders


### PR DESCRIPTION
## What this patch does to fix the issue.
This patch makes blueoil/utils compatible with tf2

Here's what I did:

install newest tenosrflow (tensorflow-gpu==1.5.2)
Run the upgrade script tf_upgrade_v2
Check the upgrade report for warnings and errors
Run test (make test)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade
