### PR TITLE
Apply tf_upgrade_v2 for output_template

### DIFF
--- a/output_template/python/lmnet/tensorflow_graph_runner.py
+++ b/output_template/python/lmnet/tensorflow_graph_runner.py
@@ -37,16 +37,16 @@ class TensorflowGraphRunner:
 
         with graph.as_default():
             with open(self.model_path, 'rb') as f:
-                graph_def = tf.GraphDef()
+                graph_def = tf.compat.v1.GraphDef()
                 graph_def.ParseFromString(f.read())
                 tf.import_graph_def(graph_def, name="")
-            init_op = tf.global_variables_initializer()
+            init_op = tf.compat.v1.global_variables_initializer()
             self.images_placeholder = graph.get_tensor_by_name('images_placeholder:0')
             self.output_op = graph.get_tensor_by_name('output:0')
 
-        session_config = tf.ConfigProto()
+        session_config = tf.compat.v1.ConfigProto()
         session_config.gpu_options.allow_growth = True
-        self.sess = tf.Session(graph=graph, config=session_config)
+        self.sess = tf.compat.v1.Session(graph=graph, config=session_config)
 
         self.sess.run(init_op)
 


### PR DESCRIPTION
## What this patch does to fix the issue.
I have realized that output_template has a python file using TensorFlow (output_template/python/lmnet/tensorflow_graph_runner.py)

This patch makes output_template/python/lmnet/tensorflow_graph_runner.py compatible with tf2

Here's what I did:
1. install newest tenosrflow (tensorflow-gpu==1.5.2)
2. Run the upgrade script tf_upgrade_v2 for `output_template`
3. Check the upgrade report for warnings and errors
4. Run test (make test)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade
