### PR TITLE
Fix checkpoint loader to use GFile

### DIFF
--- a/blueoil/cmd/train.py
+++ b/blueoil/cmd/train.py
@@ -395,8 +395,8 @@ def train(config_file, experiment_id=None, recreate=False):
     if not tf.io.gfile.exists(checkpoint):
         raise Exception('Checkpoints are not created in {}'.format(experiment_dir))
 
-    with open(checkpoint) as stream:
-        data = yaml.load(stream)
+    with tf.io.gfile.GFile(checkpoint) as stream:
+        data = yaml.load(stream, Loader=yaml.FullLoader)
     checkpoint_name = os.path.basename(data['model_checkpoint_path'])
 
     return experiment_id, checkpoint_name

--- a/blueoil/cmd/train.py
+++ b/blueoil/cmd/train.py
@@ -396,7 +396,7 @@ def train(config_file, experiment_id=None, recreate=False):
         raise Exception('Checkpoints are not created in {}'.format(experiment_dir))
 
     with tf.io.gfile.GFile(checkpoint) as stream:
-        data = yaml.load(stream, Loader=yaml.FullLoader)
+        data = yaml.load(stream)
     checkpoint_name = os.path.basename(data['model_checkpoint_path'])
 
     return experiment_id, checkpoint_name


### PR DESCRIPTION
## What this patch does to fix the issue.
When `OUTPUT_DIR=gs://xxxx/xxx`,
Training cannot be kept running.
This is critical for gcs/s3 users