### PR TITLE
Fix comment typo in __inin__.py in blueoil/blueoil/quantizations

### DIFF
--- a/blueoil/quantizations/__init__.py
+++ b/blueoil/quantizations/__init__.py
@@ -20,7 +20,7 @@ How to use:
 .. code-block:: python
 
     quantizer = binary_mean_scaling_quantizer() # initialize quantizer
-    weights = tf.get_variable("kernel", shape=[1, 2, 3, 4]) # prepare variavle.
+    weights = tf.get_variable("kernel", shape=[1, 2, 3, 4]) # prepare variable.
     quantized_weights = quantizer(weights) # use quantizer to quantize variable
     tf.nn.conv2d(inputs, quantized_weights)
 


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix comment typo

## Link to any relevant issues or pull requests.
