### PR TITLE
Add equation support for documentation generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,10 +62,10 @@ release = '0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.imgmath',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
+    'sphinx.ext.mathjax',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## What this patch does to fix the issue.
Add Math support for HTML outputs in Sphinx
using `MathJax` (Render math via JavaScript).

Remove `imgmath` extension and
change to `mathjax` in Sphinx `conf.py`
Because 'imgmath' is not working and also require to
install other package, i.e., LaTeX and dvipng

Ref:
[1] https://www.sphinx-doc.org/en/master/usage/extensions/math.html
[2] https://www.sphinx-doc.org/en/master/usage/extensions/math.html

## Link to any relevant issues or pull requests.
Closes #949 
