### PR TITLE
Fix incorrect channel_data_format on Conv2D from `channels_first/channels_last` to `NCHW/NHWC`

### DIFF
--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -243,7 +243,7 @@ class Darknet(Base):
         self.conv_19 = conv2d(
             "conv_19", self.block_18, filters=self.num_classes, kernel_size=1,
             activation=None, use_bias=True, is_debug=self.is_debug,
-            kernel_initializer=kernel_initializer, data_format=channel_data_format,
+            kernel_initializer=kernel_initializer, data_format=self.data_format,
         )
 
         if self.is_debug:

--- a/blueoil/networks/object_detection/lm_fyolo.py
+++ b/blueoil/networks/object_detection/lm_fyolo.py
@@ -127,7 +127,7 @@ class LMFYolo(YoloV2):
         output_filters = (self.num_classes + 5) * self.boxes_per_cell
         self.block_last = conv2d("block_last", x, filters=output_filters, kernel_size=1,
                                  activation=None, use_bias=True, is_debug=self.is_debug,
-                                 data_format=channel_data_format)
+                                 data_format=self.data_format)
 
         if self.change_base_output:
 

--- a/blueoil/networks/object_detection/yolo_v2.py
+++ b/blueoil/networks/object_detection/yolo_v2.py
@@ -979,7 +979,7 @@ class YoloV2(BaseNetwork):
         self.conv_23 = conv2d(
             "conv_23", self.block_22, filters=output_filters, kernel_size=1,
             activation=None, use_bias=True, is_debug=self.is_debug,
-            data_format=channel_data_format,
+            data_format=self.data_format,
         )
 
         # assert_num_cell_y = tf.assert_equal(self.num_cell[0], tf.shape(self.conv_23)[1])


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix incorrect channel_data_format on Conv2D 

From TF api docs (https://www.tensorflow.org/api_docs/python/tf/nn/conv2d)
conv2d use `NCHW/NHWC` not `channels_first/channels_last`.

## Link to any relevant issues or pull requests.