### PR TITLE
Fix arg name in comment quantize to quantizer

### DIFF
--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -281,9 +281,9 @@ class DarknetQuantize(Darknet):
             quantize_first_convolution(bool): use quantization in first conv.
             quantize_last_convolution(bool): use quantization in last conv.
             weight_quantizer (callable): weight quantizer.
-            weight_quantize_kwargs(dict): Initialize kwargs for weight quantizer.
+            weight_quantizer_kwargs(dict): Initialize kwargs for weight quantizer.
             activation_quantizer (callable): activation quantizer
-            activation_quantize_kwargs(dict): Initialize kwargs for activation quantizer.
+            activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
         super().__init__(

--- a/blueoil/networks/object_detection/lm_fyolo.py
+++ b/blueoil/networks/object_detection/lm_fyolo.py
@@ -163,9 +163,9 @@ class LMFYoloQuantize(LMFYolo):
             quantize_first_convolution(bool): use quantization in first conv.
             quantize_last_convolution(bool): use quantization in last conv.
             weight_quantizer (callable): weight quantizer.
-            weight_quantize_kwargs(dict): Initialize kwargs for weight quantizer.
+            weight_quantizer_kwargs(dict): Initialize kwargs for weight quantizer.
             activation_quantizer (callable): activation quantizer
-            activation_quantize_kwargs(dict): Initialize kwargs for activation quantizer.
+            activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
         super().__init__(

--- a/blueoil/networks/object_detection/yolo_v2_quantize.py
+++ b/blueoil/networks/object_detection/yolo_v2_quantize.py
@@ -43,9 +43,9 @@ class YoloV2Quantize(YoloV2):
             quantize_first_convolution(bool): use quantization in first conv.
             quantize_last_convolution(bool): use quantization in last conv.
             weight_quantizer (callable): weight quantizer.
-            weight_quantize_kwargs(dict): Initialize kwargs for weight quantizer.
+            weight_quantizer_kwargs(dict): Initialize kwargs for weight quantizer.
             activation_quantizer (callable): activation quantizer
-            activation_quantize_kwargs(dict): Initialize kwargs for activation quantizer.
+            activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
         super().__init__(


### PR DESCRIPTION
## What this patch does to fix the issue.
From suggestion comments in #966, I fix all other typos as well.

weight_quantize_kwargs -> weight_quantize**r**_kwargs
activation_quantize_kwargs -> activation_quantize**r**_kwargs

## Link to any relevant issues or pull requests.

_Originally posted by @iizukak in https://github.com/blue-oil/blueoil/pull/966#discussion_r404463559