### PR TITLE
Rollback Sphinx version to 2.4.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==2.4.4
 recommonmark
 sphinx_rtd_theme
 


### PR DESCRIPTION
## What this patch does to fix the issue.
There is no fix version of `Sphinx`, thus it always keeps updated to the latest version, or keeps using the currently installed version in the environment.

Now `Sphinx==3.0.0` is just released and contains some bug which leads to document generation errors.

So I fix the `Sphinx` version to the latest useable `2.4.4`.

## Link to any relevant issues or pull requests.
Closes #968

Other people got this issue as well.
https://github.com/sphinx-doc/sphinx/issues/7429
