### PR TITLE
Update version of Pillow library to fix security problem

### DIFF
--- a/output_template/python/requirements.txt
+++ b/output_template/python/requirements.txt
@@ -1,7 +1,7 @@
 click==6.7
 easydict==1.6
 numpy==1.14.0
-Pillow==6.2.1
+Pillow==6.2.2
 PyYAML==4.2b4
 
 # for python2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
   matplotlib==3.1.1
   numpy==1.18.1
   pandas==1.0.1
-  Pillow==6.2.1
+  Pillow==6.2.2
   prompt_toolkit==3.0.3
   pytablewriter==0.47.0
   PyYAML==5.3


### PR DESCRIPTION
## What this patch does to fix the issue.
A security problem exists for version 6.2.1 of Pillow library.
This patch fixes the problem.

## Link to any relevant issues or pull requests.