### PR TITLE
Refactor for consistency in blueoil/networks directory

### DIFF
--- a/blueoil/networks/classification/base.py
+++ b/blueoil/networks/classification/base.py
@@ -27,16 +27,8 @@ class Base(BaseNetwork):
 
     """
 
-    def __init__(
-            self,
-            weight_decay_rate=None,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+    def __init__(self, weight_decay_rate=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.weight_decay_rate = weight_decay_rate
 

--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -270,9 +270,9 @@ class DarknetQuantize(Darknet):
             quantize_first_convolution=True,
             quantize_last_convolution=True,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -293,9 +293,6 @@ class DarknetQuantize(Darknet):
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -286,10 +286,7 @@ class DarknetQuantize(Darknet):
             activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+        super().__init__(*args, **kwargs)
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution

--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -25,15 +25,8 @@ from blueoil.layers import conv2d, max_pooling2d
 class Darknet(Base):
     """Darknet 19 layer"""
 
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.activation = lambda x: tf.nn.leaky_relu(x, alpha=0.1, name="leaky_relu")
         self.before_last_activation = self.activation

--- a/blueoil/networks/classification/darknet.py
+++ b/blueoil/networks/classification/darknet.py
@@ -294,8 +294,8 @@ class DarknetQuantize(Darknet):
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
 
-        activation_quantizer_kwargs = activation_quantizer_kwargs if not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if not None else {}
+        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
+        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/classification/lm_resnet.py
+++ b/blueoil/networks/classification/lm_resnet.py
@@ -143,10 +143,7 @@ class LmResnetQuantize(LmResnet):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/classification/lm_resnet.py
+++ b/blueoil/networks/classification/lm_resnet.py
@@ -137,9 +137,9 @@ class LmResnetQuantize(LmResnet):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -150,9 +150,6 @@ class LmResnetQuantize(LmResnet):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lm_resnet.py
+++ b/blueoil/networks/classification/lm_resnet.py
@@ -148,8 +148,8 @@ class LmResnetQuantize(LmResnet):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -122,9 +122,9 @@ class LmnetV0Quantize(LmnetV0):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -135,9 +135,6 @@ class LmnetV0Quantize(LmnetV0):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -133,8 +133,8 @@ class LmnetV0Quantize(LmnetV0):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -26,15 +26,8 @@ class LmnetV0(Base):
     """
     version = 0.01
 
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.activation = tf.nn.relu
         self.custom_getter = None

--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -128,10 +128,7 @@ class LmnetV0Quantize(LmnetV0):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/classification/lmnet_v1.py
+++ b/blueoil/networks/classification/lmnet_v1.py
@@ -139,8 +139,8 @@ class LmnetV1Quantize(LmnetV1):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lmnet_v1.py
+++ b/blueoil/networks/classification/lmnet_v1.py
@@ -26,15 +26,8 @@ class LmnetV1(Base):
     """
     version = 1.0
 
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.activation = tf.nn.relu
         self.custom_getter = None

--- a/blueoil/networks/classification/lmnet_v1.py
+++ b/blueoil/networks/classification/lmnet_v1.py
@@ -128,9 +128,9 @@ class LmnetV1Quantize(LmnetV1):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -141,9 +141,6 @@ class LmnetV1Quantize(LmnetV1):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/classification/lmnet_v1.py
+++ b/blueoil/networks/classification/lmnet_v1.py
@@ -134,10 +134,7 @@ class LmnetV1Quantize(LmnetV1):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/classification/mobilenet_v2.py
+++ b/blueoil/networks/classification/mobilenet_v2.py
@@ -35,10 +35,7 @@ class MobileNetV2(Base):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         self.activation = tf.nn.relu6
         self.custom_getter = None

--- a/blueoil/networks/classification/vgg16.py
+++ b/blueoil/networks/classification/vgg16.py
@@ -21,20 +21,10 @@ VGG_MEAN = [103.939, 116.779, 123.68]
 
 
 class Vgg16Network(BaseNetwork):
-    def __init__(
-            self,
-            num_classes,
-            optimizer_class,
-            optimizer_args,
-            is_debug=False
-    ):
+    def __init__(self, num_classes, optimizer_class, optimizer_args, is_debug=False):
 
         self.num_classes = num_classes
-        super().__init__(
-            optimizer_class=optimizer_class,
-            optimizer_args=optimizer_args,
-            is_debug=is_debug
-        )
+        super().__init__(optimizer_class=optimizer_class, optimizer_args=optimizer_args, is_debug=is_debug)
 
     def build(self, images, is_training):
         keep_prob = tf.cond(is_training, lambda: tf.constant(0.5), lambda: tf.constant(1.0))

--- a/blueoil/networks/keypoint_detection/lm_single_pose_v1.py
+++ b/blueoil/networks/keypoint_detection/lm_single_pose_v1.py
@@ -154,9 +154,9 @@ class LmSinglePoseV1Quantize(LmSinglePoseV1):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -164,9 +164,6 @@ class LmSinglePoseV1Quantize(LmSinglePoseV1):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/keypoint_detection/lm_single_pose_v1.py
+++ b/blueoil/networks/keypoint_detection/lm_single_pose_v1.py
@@ -162,8 +162,8 @@ class LmSinglePoseV1Quantize(LmSinglePoseV1):
     ):
         super().__init__(*args, **kwargs)
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/object_detection/lm_fyolo.py
+++ b/blueoil/networks/object_detection/lm_fyolo.py
@@ -152,9 +152,9 @@ class LMFYoloQuantize(LMFYolo):
             quantize_first_convolution=True,
             quantize_last_convolution=True,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -175,9 +175,6 @@ class LMFYoloQuantize(LMFYolo):
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/object_detection/lm_fyolo.py
+++ b/blueoil/networks/object_detection/lm_fyolo.py
@@ -176,8 +176,8 @@ class LMFYoloQuantize(LMFYolo):
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
 
-        activation_quantizer_kwargs = activation_quantizer_kwargs if not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if not None else {}
+        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
+        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/object_detection/lm_fyolo.py
+++ b/blueoil/networks/object_detection/lm_fyolo.py
@@ -168,10 +168,7 @@ class LMFYoloQuantize(LMFYolo):
             activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+        super().__init__(*args, **kwargs)
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution

--- a/blueoil/networks/object_detection/yolo_v1.py
+++ b/blueoil/networks/object_detection/yolo_v1.py
@@ -42,10 +42,7 @@ class YoloV1(BaseNetwork):
             **kwargs
     ):
 
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         self.cell_size = cell_size
         self.boxes_per_cell = boxes_per_cell

--- a/blueoil/networks/object_detection/yolo_v2.py
+++ b/blueoil/networks/object_detection/yolo_v2.py
@@ -75,10 +75,7 @@ class YoloV2(BaseNetwork):
             use_cross_entropy_loss(bool): Use cross entropy loss instead of mean square error of class loss.
             change_base_output(bool): If it is true, the output of network be activated with softmax and sigmoid.
         """
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         self.anchors = anchors
         self.boxes_per_cell = len(anchors)

--- a/blueoil/networks/object_detection/yolo_v2_quantize.py
+++ b/blueoil/networks/object_detection/yolo_v2_quantize.py
@@ -32,9 +32,9 @@ class YoloV2Quantize(YoloV2):
             quantize_first_convolution=True,
             quantize_last_convolution=True,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -55,9 +55,6 @@ class YoloV2Quantize(YoloV2):
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/object_detection/yolo_v2_quantize.py
+++ b/blueoil/networks/object_detection/yolo_v2_quantize.py
@@ -48,10 +48,7 @@ class YoloV2Quantize(YoloV2):
             activation_quantizer_kwargs(dict): Initialize kwargs for activation quantizer.
         """
 
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+        super().__init__(*args, **kwargs)
 
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution

--- a/blueoil/networks/object_detection/yolo_v2_quantize.py
+++ b/blueoil/networks/object_detection/yolo_v2_quantize.py
@@ -56,8 +56,8 @@ class YoloV2Quantize(YoloV2):
         self.quantize_first_convolution = quantize_first_convolution
         self.quantize_last_convolution = quantize_last_convolution
 
-        activation_quantizer_kwargs = activation_quantizer_kwargs if not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if not None else {}
+        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
+        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/segmentation/base.py
+++ b/blueoil/networks/segmentation/base.py
@@ -27,16 +27,8 @@ class Base(BaseNetwork):
 
     """
 
-    def __init__(
-            self,
-            *args,
-            label_colors=None,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+    def __init__(self, *args, label_colors=None, **kwargs):
+        super().__init__(*args, **kwargs)
         if label_colors is None:
             self.label_colors = get_color_map(self.num_classes)
         else:
@@ -145,16 +137,8 @@ class SegnetBase(Base):
     The ratio is difference from `median  frequency  balancing` described in [SegNet](https://arxiv.org/pdf/1511.00561.pdf).
     """ # NOQA
 
-    def __init__(
-            self,
-            weight_decay_rate=None,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs,
-        )
+    def __init__(self, weight_decay_rate=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.weight_decay_rate = weight_decay_rate
 

--- a/blueoil/networks/segmentation/lm_bisenet.py
+++ b/blueoil/networks/segmentation/lm_bisenet.py
@@ -374,9 +374,9 @@ class LMBiSeNetQuantize(LMBiSeNet):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -387,9 +387,6 @@ class LMBiSeNetQuantize(LMBiSeNet):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/segmentation/lm_bisenet.py
+++ b/blueoil/networks/segmentation/lm_bisenet.py
@@ -56,10 +56,7 @@ class LMBiSeNet(Base):
             use_attention_refinement (bool): Flag of using attention refinement module.
             use_tail_gap (bool): Flag of using GAP (global average pooling) followed by context path.
         """
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert self.data_format == 'NHWC'
 

--- a/blueoil/networks/segmentation/lm_bisenet.py
+++ b/blueoil/networks/segmentation/lm_bisenet.py
@@ -385,8 +385,8 @@ class LMBiSeNetQuantize(LMBiSeNet):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/segmentation/lm_bisenet.py
+++ b/blueoil/networks/segmentation/lm_bisenet.py
@@ -380,10 +380,7 @@ class LMBiSeNetQuantize(LMBiSeNet):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/segmentation/lm_segnet_v0.py
+++ b/blueoil/networks/segmentation/lm_segnet_v0.py
@@ -26,15 +26,8 @@ from blueoil.layers.experiment import max_unpool_with_argmax
 class LmSegnetV0(SegnetBase):
     """LM customized SegNet Network."""
 
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.activation = tf.nn.relu
         self.custom_getter = None

--- a/blueoil/networks/segmentation/lm_segnet_v0.py
+++ b/blueoil/networks/segmentation/lm_segnet_v0.py
@@ -124,10 +124,7 @@ class LmSegnetV0Quantize(LmSegnetV0):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/segmentation/lm_segnet_v0.py
+++ b/blueoil/networks/segmentation/lm_segnet_v0.py
@@ -118,9 +118,9 @@ class LmSegnetV0Quantize(LmSegnetV0):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -131,9 +131,6 @@ class LmSegnetV0Quantize(LmSegnetV0):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/segmentation/lm_segnet_v0.py
+++ b/blueoil/networks/segmentation/lm_segnet_v0.py
@@ -129,8 +129,8 @@ class LmSegnetV0Quantize(LmSegnetV0):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/segmentation/lm_segnet_v1.py
+++ b/blueoil/networks/segmentation/lm_segnet_v1.py
@@ -26,15 +26,8 @@ class LmSegnetV1(SegnetBase):
        This network is composed of 11 convolution layers with space_to_depth and depth_to_space.
     """
 
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.activation = tf.nn.relu
         self.custom_getter = None

--- a/blueoil/networks/segmentation/lm_segnet_v1.py
+++ b/blueoil/networks/segmentation/lm_segnet_v1.py
@@ -121,8 +121,8 @@ class LmSegnetV1Quantize(LmSegnetV1):
             **kwargs
         )
 
-        assert weight_quantizer
-        assert activation_quantizer
+        assert callable(weight_quantizer)
+        assert callable(activation_quantizer)
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)

--- a/blueoil/networks/segmentation/lm_segnet_v1.py
+++ b/blueoil/networks/segmentation/lm_segnet_v1.py
@@ -116,10 +116,7 @@ class LmSegnetV1Quantize(LmSegnetV1):
             *args,
             **kwargs
     ):
-        super().__init__(
-            *args,
-            **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
         assert callable(weight_quantizer)
         assert callable(activation_quantizer)

--- a/blueoil/networks/segmentation/lm_segnet_v1.py
+++ b/blueoil/networks/segmentation/lm_segnet_v1.py
@@ -110,9 +110,9 @@ class LmSegnetV1Quantize(LmSegnetV1):
     def __init__(
             self,
             activation_quantizer=None,
-            activation_quantizer_kwargs=None,
+            activation_quantizer_kwargs={},
             weight_quantizer=None,
-            weight_quantizer_kwargs=None,
+            weight_quantizer_kwargs={},
             *args,
             **kwargs
     ):
@@ -123,9 +123,6 @@ class LmSegnetV1Quantize(LmSegnetV1):
 
         assert weight_quantizer
         assert activation_quantizer
-
-        activation_quantizer_kwargs = activation_quantizer_kwargs if activation_quantizer_kwargs is not None else {}
-        weight_quantizer_kwargs = weight_quantizer_kwargs if weight_quantizer_kwargs is not None else {}
 
         self.activation = activation_quantizer(**activation_quantizer_kwargs)
         weight_quantization = weight_quantizer(**weight_quantizer_kwargs)


### PR DESCRIPTION
## What this patch does to fix the issue.
Refactor code in blueoil/networks for consistency.

- [X] Change the default parameters of  `activation_quantizer_kwargs`, `weight_quantizer_kwargs` to `{}` 
 - This `a if a is not None else {}` is only necessary when we modify given args.
 - Statement if `not None` is always True.
- [X] Change the assert weight_quantizer and activation_quantizer to callable(...)
- [X] Fit __init__ into one line 

## Link to any relevant issues or pull requests.
_Originally posted by @tsawada in https://github.com/blue-oil/blueoil/pull/966#discussion_r406636416
, https://github.com/blue-oil/blueoil/pull/966#discussion_r406660794

This should be merged before #966 . (https://github.com/blue-oil/blueoil/pull/966#issuecomment-611947906)