### PR TITLE
Fixed pep8 errors "F405" in converter

### DIFF
--- a/blueoil/converter/__init__.py
+++ b/blueoil/converter/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from .env import *
+from .env import MAX_CPU_COUNT
 
 __all__ = ['MAX_CPU_COUNT']

--- a/blueoil/converter/core/operators.py
+++ b/blueoil/converter/core/operators.py
@@ -20,12 +20,14 @@ import warnings
 from termcolor import colored
 from abc import abstractmethod
 from itertools import dropwhile
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+
+import numpy as np
 
 from blueoil.converter.core.view import View
 from blueoil.converter.util import classproperty
 
-from .data_types import *
+from .data_types import DataType
 
 if TYPE_CHECKING:
     import blueoil.converter.core.operators as ops

--- a/blueoil/converter/core/params.py
+++ b/blueoil/converter/core/params.py
@@ -17,7 +17,7 @@
 from typing import List
 
 from blueoil.converter.core.config import Config
-from blueoil.converter.core.data_types import *
+from blueoil.converter.core.data_types import Uint32
 from blueoil.converter.core.operators import Conv
 
 

--- a/blueoil/converter/core/view.py
+++ b/blueoil/converter/core/view.py
@@ -16,7 +16,7 @@
 import copy
 from textwrap import dedent, indent
 
-from blueoil.converter.core.data_types import *
+from blueoil.converter.core.data_types import QUANTIZED_PACKED
 
 
 class View(object):


### PR DESCRIPTION
## What this patch does to fix the issue.
Many pep8 errors occurred because of star imports.
This PR reduces pep8 errors in converter from `432` to `96`.
```
F405 'List' may be undefined, or defined from star imports: .data_types
```

## Link to any relevant issues or pull requests.
https://github.com/blue-oil/blueoil/issues/979