### PR TITLE
Fixed pep8 errors "F841" in converter

### DIFF
--- a/blueoil/converter/core/view.py
+++ b/blueoil/converter/core/view.py
@@ -458,7 +458,6 @@ class View(object):
             inputs_string = self.inputs_to_string(op, input_ops)
             shape_string = self.shape_to_string(op.shape)
 
-            number_of_inputs = len(input_ops)
             concat_input = {}
             for k, v in input_ops.items():
                 if not v.is_variable:
@@ -495,9 +494,6 @@ class View(object):
                 """
             )
         elif self.op.op_type == 'ResizeNearestNeighbor':
-
-            args1 = f"{inputs_string}, {op.name}"
-
             return self.format_string(
                 f"""
                 func_ResizeNearestNeighbor({inputs_string}, {outputs_string});

--- a/blueoil/converter/plugins/tf.py
+++ b/blueoil/converter/plugins/tf.py
@@ -470,7 +470,6 @@ class Importer(object):
         - 'Transpose': depending on the permutation attribute
         """
 
-        _default_format = 'NHWC'
         _default_w_format = 'HWIO'
 
         rank_to_format = {0: 'Atom', 1: 'C', 2: 'HW', 3: 'HWC', 4: 'NHWC', 5: 'NHWCT'}

--- a/tests/converter/test_consistency_check.py
+++ b/tests/converter/test_consistency_check.py
@@ -40,7 +40,7 @@ class TestConsistencyCheck(unittest.TestCase):
             np.zeros([3])
         )
         input_ops = {'A': cast(Operator, a), 'B': cast(Operator, b)}
-        add = Add(
+        Add(
             'add1',
             [1, 3, 3],
             Float32(),
@@ -63,7 +63,7 @@ class TestConsistencyCheck(unittest.TestCase):
         )
         input_ops = {'A': cast(Operator, a), 'B': cast(Operator, b)}
         try:
-            add = Add(
+            Add(
                 'add1',
                 [1, 3, 3],
                 Float32(),
@@ -84,7 +84,7 @@ class TestConsistencyCheck(unittest.TestCase):
         )
         input_ops = {'X': cast(Operator, x)}
 
-        add = MaxPool(
+        MaxPool(
             'max_pool1',
             [1, 2, 2, 3],
             Float32(),
@@ -110,7 +110,7 @@ class TestConsistencyCheck(unittest.TestCase):
         )
         input_ops = {'X': cast(Operator, x), 'W': cast(Operator, w)}
 
-        add = Conv(
+        Conv(
             'conv_under_test',
             [1, 3, 3, 3],
             Float32(),

--- a/tests/converter/test_operators.py
+++ b/tests/converter/test_operators.py
@@ -39,7 +39,7 @@ class TestOperators(unittest.TestCase):
             np.zeros([1, 3, 3, 3])
         )
         inputs: Dict[str, Operator] = {i_names[0]: x}
-        m = MaxPool(
+        MaxPool(
             "MaxPool",
             [1, 2, 2, 3],
             Float32(),


### PR DESCRIPTION
## What this patch does to fix the issue.
Fixed pep8 errors about `local variable 'X' is assigned to but never used`.

## Link to any relevant issues or pull requests.
#979 