### PR TITLE
Add table support in markdown (.md) file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
     'autoapi.extension',
+    'sphinx_markdown_tables',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 sphinx==2.4.4
 recommonmark
 sphinx_rtd_theme
+sphinx-markdown-tables
 
 # for auto api
 sphinx-autoapi


### PR DESCRIPTION
## What this patch does to fix the issue.
This commit add `sphinx-markdown-tables` to blueoil document in order to have table compatible in a markdown file.

https://pypi.org/project/sphinx-markdown-tables/

## Link to any relevant issues or pull requests.
Closes #1003 