### PR TITLE
Clean Up Makefile of Runtime

### DIFF
--- a/blueoil/cmd/convert.py
+++ b/blueoil/cmd/convert.py
@@ -100,21 +100,21 @@ def make_all(project_dir, output_dir):
     """
 
     make_list = [
-        ["lm_x86", "lm_x86.elf"],
-        ["lm_x86_avx", "lm_x86_avx.elf"],
-        ["lm_arm", "lm_arm.elf"],
-        ["lm_fpga", "lm_fpga.elf"],
-        ["lm_aarch64", "lm_aarch64.elf"],
-        ["lib_x86", "libdlk_x86.so"],
-        ["lib_x86_avx", "libdlk_x86_avx.so"],
-        ["lib_arm", "libdlk_arm.so"],
-        ["lib_fpga", "libdlk_fpga.so"],
-        ["lib_aarch64", "libdlk_aarch64.so"],
-        ["ar_x86", "libdlk_x86.a"],
-        ["ar_x86_avx", "libdlk_x86_avx.a"],
-        ["ar_arm", "libdlk_arm.a"],
-        ["ar_fpga", "libdlk_fpga.a"],
-        ["ar_aarch64", "libdlk_aarch64.a"],
+        ["ARCH=x86 TYPE=executable", "lm_x86.elf"],
+        ["ARCH=x86_avx TYPE=executable", "lm_x86_avx.elf"],
+        ["ARCH=arm TYPE=executable", "lm_arm.elf"],
+        ["ARCH=fpga TYPE=executable", "lm_fpga.elf"],
+        ["ARCH=aarch64 TYPE=executable", "lm_aarch64.elf"],
+        ["ARCH=x86 TYPE=dynamic", "libdlk_x86.so"],
+        ["ARCH=x86_avx TYPE=dynamic", "libdlk_x86_avx.so"],
+        ["ARCH=arm TYPE=dynamic", "libdlk_arm.so"],
+        ["ARCH=fpga TYPE=dynamic", "libdlk_fpga.so"],
+        ["ARCH=aarch64 TYPE=dynamic", "libdlk_aarch64.so"],
+        ["ARCH=x86 TYPE=static", "libdlk_x86.a"],
+        ["ARCH=x86_avx TYPE=static", "libdlk_x86_avx.a"],
+        ["ARCH=arm TYPE=static", "libdlk_arm.a"],
+        ["ARCH=fpga TYPE=static", "libdlk_fpga.a"],
+        ["ARCH=aarch64 TYPE=static", "libdlk_aarch64.a"],
     ]
     output_dir = os.path.abspath(output_dir)
     running_dir = os.getcwd()
@@ -124,7 +124,7 @@ def make_all(project_dir, output_dir):
     # Make each target and move output files
     for target, output in make_list:
         subprocess.run(("make", "clean", "--quiet"))
-        subprocess.run(("make", target, "-j4", "--quiet"))
+        subprocess.run(("make", "build", target, "-j4", "--quiet"))
         strip_binary(output)
         output_file_path = os.path.join(output_dir, output)
         os.rename(output, output_file_path)

--- a/blueoil/cmd/convert.py
+++ b/blueoil/cmd/convert.py
@@ -100,21 +100,21 @@ def make_all(project_dir, output_dir):
     """
 
     make_list = [
-        ["ARCH=x86 TYPE=executable", "lm_x86.elf"],
-        ["ARCH=x86_avx TYPE=executable", "lm_x86_avx.elf"],
-        ["ARCH=arm TYPE=executable", "lm_arm.elf"],
-        ["ARCH=fpga TYPE=executable", "lm_fpga.elf"],
-        ["ARCH=aarch64 TYPE=executable", "lm_aarch64.elf"],
-        ["ARCH=x86 TYPE=dynamic", "libdlk_x86.so"],
-        ["ARCH=x86_avx TYPE=dynamic", "libdlk_x86_avx.so"],
-        ["ARCH=arm TYPE=dynamic", "libdlk_arm.so"],
-        ["ARCH=fpga TYPE=dynamic", "libdlk_fpga.so"],
-        ["ARCH=aarch64 TYPE=dynamic", "libdlk_aarch64.so"],
-        ["ARCH=x86 TYPE=static", "libdlk_x86.a"],
-        ["ARCH=x86_avx TYPE=static", "libdlk_x86_avx.a"],
-        ["ARCH=arm TYPE=static", "libdlk_arm.a"],
-        ["ARCH=fpga TYPE=static", "libdlk_fpga.a"],
-        ["ARCH=aarch64 TYPE=static", "libdlk_aarch64.a"],
+        ["ARCH=x86", "TYPE=executable", "lm_x86.elf"],
+        ["ARCH=x86_avx", "TYPE=executable", "lm_x86_avx.elf"],
+        ["ARCH=arm", "TYPE=executable", "lm_arm.elf"],
+        ["ARCH=fpga", "TYPE=executable", "lm_fpga.elf"],
+        ["ARCH=aarch64", "TYPE=executable", "lm_aarch64.elf"],
+        ["ARCH=x86", "TYPE=dynamic", "libdlk_x86.so"],
+        ["ARCH=x86_avx", "TYPE=dynamic", "libdlk_x86_avx.so"],
+        ["ARCH=arm", "TYPE=dynamic", "libdlk_arm.so"],
+        ["ARCH=fpga", "TYPE=dynamic", "libdlk_fpga.so"],
+        ["ARCH=aarch64", "TYPE=dynamic", "libdlk_aarch64.so"],
+        ["ARCH=x86", "TYPE=static", "libdlk_x86.a"],
+        ["ARCH=x86_avx", "TYPE=static", "libdlk_x86_avx.a"],
+        ["ARCH=arm", "TYPE=static", "libdlk_arm.a"],
+        ["ARCH=fpga", "TYPE=static", "libdlk_fpga.a"],
+        ["ARCH=aarch64", "TYPE=static", "libdlk_aarch64.a"],
     ]
     output_dir = os.path.abspath(output_dir)
     running_dir = os.getcwd()
@@ -122,9 +122,9 @@ def make_all(project_dir, output_dir):
     os.chdir(project_dir)
 
     # Make each target and move output files
-    for target, output in make_list:
+    for target_arch, target_type, output in make_list:
         subprocess.run(("make", "clean", "--quiet"))
-        subprocess.run(("make", "build", target, "-j4", "--quiet"))
+        subprocess.run(("make", "build", target_arch, target_type, "-j4", "--quiet"))
         strip_binary(output)
         output_file_path = os.path.join(output_dir, output)
         os.rename(output, output_file_path)

--- a/blueoil/converter/templates/Makefile
+++ b/blueoil/converter/templates/Makefile
@@ -1,7 +1,11 @@
 SRC_DIR := ./src
 MAINS_DIR := ./mains
 INPUTS_SRC_DIR := ./src/inputs
-DLK_TEST_SRC_DIR := ./src/test_data
+
+.PHONY: help
+help:
+	@echo make clean
+	@echo make build ARCH={x86, x86_avx, aarch64, arm, fpga} TYPE={executable, dynamic, static}
 
 LIB_SRC := $(wildcard $(INPUTS_SRC_DIR)/*.cpp) \
     $(wildcard $(SRC_DIR)/scaling_factors.cpp) \
@@ -67,39 +71,14 @@ OBJ := $(patsubst %.cpp, %.o, $(SRC))
 
 INCLUDES := -I./include
 
+ALL_OBJ := \
+    $(OBJ) $(LIB_OBJ) \
+    $(LIB_X86_OBJ) $(LIB_X86_AVX_OBJ) \
+    $(LIB_AARCH64_OBJ) \
+    $(LIB_ARM_OBJ) $(LIB_FPGA_OBJ)
 
-TARGETS_X86  := lm_x86
-
-TARGETS_X86_AVX  := lm_x86_avx
-
-TARGETS_AARCH64 := lm_aarch64
-
-TARGETS_ARM  := lm_arm
-
-TARGETS_FPGA := lm_fpga
-
-LIBS_X86     := lib_x86
-
-LIBS_X86_AVX := lib_x86_avx
-
-LIBS_AARCH64 := lib_aarch64
-
-LIBS_ARM     := lib_arm
-
-LIBS_FPGA    := lib_fpga
-
-ARS_X86     := ar_x86
-
-ARS_X86_AVX := ar_x86_avx
-
-ARS_AARCH64 := ar_aarch64
-
-ARS_X86     := ar_x86
-
-ARS_ARM     := ar_arm
-
-ARS_FPGA    := ar_fpga
-
+ALL_DEP := $(ALL_OBJ:.o=.d)
+-include $(ALL_DEP)
 
 RM       := rm -rf
 
@@ -108,139 +87,101 @@ clean:
 	-$(RM) *.elf
 	-$(RM) *.a
 	-$(RM) *.so
-	-$(RM) $(LIB_OBJ)
-	-$(RM) $(LIB_X86_OBJ)
-	-$(RM) $(LIB_X86_AVX_OBJ)
-	-$(RM) $(LIB_ARM_OBJ)
-	-$(RM) $(LIB_FPGA_OBJ)
-	-$(RM) $(LIB_AARCH64_OBJ)
-	-$(RM) $(OBJ)
+	-$(RM) $(ALL_OBJ)
+	-$(RM) $(ALL_DEP)
 
-lm_x86:           CXX = g++
-lm_x86:           FLAGS += $(INCLUDES) -O3 -std=c++14 -DUSE_PNG -pthread -g -DFUNC_TIME_MEASUREMENT
-lm_x86:           CXXFLAGS +=
+################################
+# Set variables by ARCH
+################################
 
-lm_x86_avx:       CXX = g++
-lm_x86_avx:       FLAGS += $(INCLUDES) -O3 -std=c++14 -mavx2 -mfma -DUSE_AVX -DUSE_PNG -pthread -g -fopenmp -DFUNC_TIME_MEASUREMENT
-lm_x86_avx:       CXXFLAGS +=
+# Base Settings
+FLAGS := -I./include -O3 -std=c++14 -g -MMD -MP
+ARFLAGS := -rcs
+LDFLAGS += -pthread -ldl
 
-lm_aarch64:       CXX = aarch64-linux-gnu-g++
-lm_aarch64:       FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DUSE_PNG -pthread -g -fopenmp -DFUNC_TIME_MEASUREMENT
-lm_aarch64:       CXXFLAGS +=
+ifeq ($(ARCH), x86)
+CPU := cpu_x86
+FLAGS +=
+SRC := $(SRC) $(LIB_X86_SRC)
+endif
 
-lm_arm:           CXX = arm-linux-gnueabihf-g++
-lm_arm:           FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DUSE_PNG -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -s -pthread -g -fopenmp -DFUNC_TIME_MEASUREMENT
-lm_arm:           CXXFLAGS +=
+ifeq ($(ARCH), x86_avx)
+CPU := cpu_x86
+FLAGS += -mavx2 -mfma -DUSE_AVX -fopenmp
+SRC := $(SRC) $(LIB_X86_AVX_SRC)
+endif
 
-lm_fpga:          CXX = arm-linux-gnueabihf-g++
-lm_fpga:          FLAGS += $(INCLUDES) -std=c++14 -O3 -DUSE_NEON -DRUN_ON_FPGA -DUSE_PNG -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -pthread -g -fopenmp -DFUNC_TIME_MEASUREMENT
-lm_fpga:          CXXFLAGS +=
+ifeq ($(ARCH), aarch64)
+CPU := cpu_aarch64
+FLAGS +=
+SRC := $(SRC) $(LIB_AARCH64_SRC)
+endif
 
-.PHONY: lib_x86 lib_x86_avx lib_aarch64 lib_arm lib_fpga
+ifeq ($(ARCH), arm)
+CPU := cpu_arm
+FLAGS +=
+SRC := $(SRC) $(LIB_ARM_SRC)
+endif
 
-lib_x86:           CXX = g++
-lib_x86:           FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -pthread -g
-lib_x86:           CXXFLAGS +=
-lib_x86:           NAME = x86
+ifeq ($(ARCH), fpga)
+CPU := cpu_arm
+FLAGS += -DRUN_ON_FPGA
+SRC := $(SRC) $(LIB_FPGA_SRC)
+endif
 
-lib_x86_avx:       CXX = g++
-lib_x86_avx:       FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -DUSE_AVX -mavx2 -mfma -pthread -g -fopenmp
-lib_x86_avx:       CXXFLAGS +=
-lib_x86_avx:       NAME = x86_avx
+################################
+# Set variables by CPU
+################################
+ifeq($(CPU), cpu_x86)
+CXX := g++
+FLAGS +=
+AR = ar
+endif
 
-lib_aarch64:       CXX = aarch64-linux-gnu-g++
-lib_aarch64:       FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -DUSE_NEON -pthread -g
-lib_aarch64:       CXXFLAGS +=
-lib_aarch64:       NAME = aarch64
+ifeq($(CPU), cpu_aarch64)
+CXX := aarch64-linux-gnu-g++
+FLAGS += -DUSE_NEON -fopenmp
+AR = aarch64-linux-gnu-ar
+endif
 
-lib_arm:           CXX = arm-linux-gnueabihf-g++
-lib_arm:           FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fvisibility=hidden -pthread -g -fopenmp
-lib_arm:           CXXFLAGS +=
-lib_arm:           NAME = arm
+ifeq($(CPU), cpu_arm)
+CXX := arm-linux-gnueabihf-g++
+FLAGS += -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fopenmp
+AR = arm-linux-gnueabihf-ar
+endif
 
-lib_fpga:          CXX = arm-linux-gnueabihf-g++
-lib_fpga:          FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -DUSE_NEON -DRUN_ON_FPGA -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fvisibility=hidden -pthread -g -fopenmp
-lib_fpga:          CXXFLAGS +=
-lib_fpga:          NAME = fpga
+################################
+# Set variables by TYPE
+################################
+ifeq ($(TYPE), executable)
+FLAGS += -DUSE_PNG -DFUNC_TIME_MEASUREMENT
+NAME := lm_$(ARCH).elf
+LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
+endif
 
-ar_x86:           AR = ar
-ar_x86:           CXX = g++
-ar_x86:           FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -pthread -g
-ar_x86:           LDFLAGS += -rcs
-ar_x86:           NAME = x86
+ifeq ($(TYPE), dynamic)
+FLAGS += -fPIC -fvisibility=hidden
+NAME := libdlk_$(ARCH).so
+LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
+endif
 
-ar_x86_avx:       AR = ar
-ar_x86_avx:       CXX = g++
-ar_x86_avx:       FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -DUSE_AVX -mavx2 -mfma -pthread -g -fopenmp
-ar_x86_avx:       LDFLAGS += -rcs
-ar_x86_avx:       NAME = x86_avx
-
-ar_aarch64:       AR = aarch64-linux-gnu-ar
-ar_aarch64:       CXX = aarch64-linux-gnu-g++
-ar_aarch64:       FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -fvisibility=hidden -DUSE_NEON -pthread -g
-ar_aarch64:       LDFLAGS += -rcs
-ar_aarch64:       NAME = aarch64
-
-ar_arm:           AR = arm-linux-gnueabihf-ar
-ar_arm:           CXX = arm-linux-gnueabihf-g++
-ar_arm:           FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fvisibility=hidden -pthread -g -fopenmp
-ar_arm:           LDFLAGS += -rcs
-ar_arm:           NAME = arm
-
-ar_fpga:          AR = arm-linux-gnueabihf-ar
-ar_fpga:          CXX = arm-linux-gnueabihf-g++
-ar_fpga:          FLAGS += $(INCLUDES) -O3 -std=c++14 -fPIC -DUSE_NEON -DRUN_ON_FPGA -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fvisibility=hidden -pthread -g -fopenmp
-ar_fpga:          LDFLAGS += -rcs
-ar_fpga:          NAME = fpga
+ifeq ($(TYPE), static)
+FLAGS += -fPIC -fvisibility=hidden
+NAME := libdlk_$(ARCH).a
+LINK := $(AR) $(ARFLAGS) $(NAME) $(OBJ)
+endif
 
 
-$(TARGETS_ARM): $(OBJ) $(LIB_ARM_OBJ)
-	$(CXX) $(FLAGS) $(OBJ) $(LIB_ARM_OBJ) -o $@.elf $(CXXFLAGS) -pthread -ldl
+.PHONY: build
+build: $(NAME)
+	@echo Building $(NAME)
 
-$(TARGETS_FPGA): $(OBJ) $(LIB_FPGA_OBJ)
-	$(CXX) $(FLAGS) $(OBJ) $(LIB_FPGA_OBJ) -o $@.elf $(CXXFLAGS) -pthread -ldl
-
-$(TARGETS_AARCH64): $(OBJ) $(LIB_AARCH64_OBJ)
-	$(CXX) $(FLAGS) $(OBJ) $(LIB_AARCH64_OBJ) -o $@.elf $(CXXFLAGS) -pthread -ldl
-
-$(TARGETS_X86): $(OBJ) $(LIB_X86_OBJ)
-	$(CXX) $(FLAGS) $(OBJ) $(LIB_X86_OBJ) -o $@.elf $(CXXFLAGS) -pthread -ldl
-
-$(TARGETS_X86_AVX): $(OBJ) $(LIB_X86_AVX_OBJ)
-	$(CXX) $(FLAGS) $(OBJ) $(LIB_X86_AVX_OBJ) -o $@.elf $(CXXFLAGS) -pthread -ldl
-
-$(LIBS_X86): $(LIB_OBJ) $(LIB_X86_OBJ)
-	$(CXX) $(FLAGS) $(LIB_OBJ) $(LIB_X86_OBJ) -o libdlk_$(NAME).so $(CXXFLAGS) -shared -pthread -ldl
-
-$(LIBS_X86_AVX): $(LIB_OBJ) $(LIB_X86_AVX_OBJ)
-	$(CXX) $(FLAGS) $(LIB_OBJ) $(LIB_X86_AVX_OBJ) -o libdlk_$(NAME).so $(CXXFLAGS) -shared -pthread -ldl
-
-$(LIBS_AARCH64): $(LIB_OBJ) $(LIB_AARCH64_OBJ)
-	$(CXX) $(FLAGS) $(LIB_OBJ) $(LIB_AARCH64_OBJ) -o libdlk_$(NAME).so $(CXXFLAGS) -shared -pthread -ldl
-
-$(LIBS_ARM): $(LIB_OBJ) $(LIB_ARM_OBJ)
-	$(CXX) $(FLAGS) $(LIB_OBJ) $(LIB_ARM_OBJ) -o libdlk_$(NAME).so $(CXXFLAGS) -shared -pthread -ldl
-
-$(LIBS_FPGA): $(LIB_OBJ) $(LIB_FPGA_OBJ)
-	$(CXX) $(FLAGS) $(LIB_OBJ) $(LIB_FPGA_OBJ) -o libdlk_$(NAME).so $(CXXFLAGS) -shared -pthread -ldl
-
-$(ARS_X86): $(LIB_OBJ) $(LIB_X86_OBJ)
-	$(AR) $(LDFLAGS) libdlk_$(NAME).a $(LIB_OBJ) $(LIB_X86_OBJ)
-
-$(ARS_X86_AVX): $(LIB_OBJ) $(LIB_X86_AVX_OBJ)
-	$(AR) $(LDFLAGS) libdlk_$(NAME).a $(LIB_OBJ) $(LIB_X86_AVX_OBJ)
-
-$(ARS_AARCH64): $(LIB_OBJ) $(LIB_AARCH64_OBJ)
-	$(AR) $(LDFLAGS) libdlk_$(NAME).a $(LIB_OBJ) $(LIB_AARCH64_OBJ)
-
-$(ARS_ARM): $(LIB_OBJ) $(LIB_ARM_OBJ)
-	$(AR) $(LDFLAGS) libdlk_$(NAME).a $(LIB_OBJ) $(LIB_ARM_OBJ)
-
-$(ARS_FPGA): $(LIB_OBJ) $(LIB_FPGA_OBJ)
-	$(AR) $(LDFLAGS) libdlk_$(NAME).a $(LIB_OBJ) $(LIB_FPGA_OBJ)
+$(NAME): $(OBJ)
+	$(LINK)
 
 %.o: %.S
-	$(CXX) $(FLAGS) -c $^ -o $@ $(CXXFLAGS)
+	$(CXX) $(FLAGS) -c $< -o $@ $(CXXFLAGS)
 
 %.o: %.cpp
-	$(CXX) $(FLAGS) -c $^ -o $@ $(CXXFLAGS)
+	$(CXX) $(FLAGS) -c $< -o $@ $(CXXFLAGS)
+

--- a/blueoil/converter/templates/Makefile
+++ b/blueoil/converter/templates/Makefile
@@ -27,8 +27,8 @@ LIB_SRC := $(wildcard $(INPUTS_SRC_DIR)/*.cpp) \
     $(SRC_DIR)/quantizer.cpp \
     $(SRC_DIR)/tensor_save.cpp
 
-SRC := $(LIB_SRC) $(wildcard $(DLK_TEST_SRC_DIR)/*.cpp) mains/main.cpp
-SRC := $(filter-out ./src/network_c_interface.cpp, $(SRC))
+MAIN_SRC := $(LIB_SRC) mains/main.cpp
+MAIN_SRC := $(filter-out ./src/network_c_interface.cpp, $(MAIN_SRC))
 
 LIB_ARM_SRC := $(wildcard $(SRC_DIR)/*.S) \
     $(SRC_DIR)/func/arm_neon/batch_normalization.cpp \
@@ -67,12 +67,12 @@ LIB_X86_AVX_SRC := \
 LIB_X86_AVX_OBJ := $(patsubst %.cpp, %.o, $(LIB_X86_AVX_SRC))
 
 LIB_OBJ := $(patsubst %.cpp, %.o, $(LIB_SRC))
-OBJ := $(patsubst %.cpp, %.o, $(SRC))
+MAIN_OBJ := $(patsubst %.cpp, %.o, $(MAIN_SRC))
 
 INCLUDES := -I./include
 
 ALL_OBJ := \
-    $(OBJ) $(LIB_OBJ) \
+    $(MAIN_OBJ) $(LIB_OBJ) \
     $(LIB_X86_OBJ) $(LIB_X86_AVX_OBJ) \
     $(LIB_AARCH64_OBJ) \
     $(LIB_ARM_OBJ) $(LIB_FPGA_OBJ)
@@ -90,61 +90,62 @@ clean:
 	-$(RM) $(ALL_OBJ)
 	-$(RM) $(ALL_DEP)
 
-################################
-# Set variables by ARCH
-################################
 
 # Base Settings
 FLAGS := -I./include -O3 -std=c++14 -g -MMD -MP
 ARFLAGS := -rcs
 LDFLAGS += -pthread -ldl
 
+################################
+# Set variables by ARCH
+################################
+
 ifeq ($(ARCH), x86)
 CPU := cpu_x86
 FLAGS +=
-SRC := $(SRC) $(LIB_X86_SRC)
+OBJ := $(LIB_X86_OBJ)
 endif
 
 ifeq ($(ARCH), x86_avx)
 CPU := cpu_x86
 FLAGS += -mavx2 -mfma -DUSE_AVX -fopenmp
-SRC := $(SRC) $(LIB_X86_AVX_SRC)
+OBJ := $(LIB_X86_AVX_OBJ)
 endif
 
 ifeq ($(ARCH), aarch64)
 CPU := cpu_aarch64
 FLAGS +=
-SRC := $(SRC) $(LIB_AARCH64_SRC)
+OBJ := $(LIB_AARCH64_OBJ)
 endif
 
 ifeq ($(ARCH), arm)
 CPU := cpu_arm
 FLAGS +=
-SRC := $(SRC) $(LIB_ARM_SRC)
+OBJ := $(LIB_ARM_OBJ)
 endif
 
 ifeq ($(ARCH), fpga)
 CPU := cpu_arm
 FLAGS += -DRUN_ON_FPGA
-SRC := $(SRC) $(LIB_FPGA_SRC)
+OBJ := $(LIB_FPGA_OBJ)
 endif
 
 ################################
 # Set variables by CPU
 ################################
-ifeq($(CPU), cpu_x86)
+ifeq ($(CPU), cpu_x86)
 CXX := g++
 FLAGS +=
 AR = ar
 endif
 
-ifeq($(CPU), cpu_aarch64)
+ifeq ($(CPU), cpu_aarch64)
 CXX := aarch64-linux-gnu-g++
 FLAGS += -DUSE_NEON -fopenmp
 AR = aarch64-linux-gnu-ar
 endif
 
-ifeq($(CPU), cpu_arm)
+ifeq ($(CPU), cpu_arm)
 CXX := arm-linux-gnueabihf-g++
 FLAGS += -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fopenmp
 AR = arm-linux-gnueabihf-ar
@@ -154,19 +155,25 @@ endif
 # Set variables by TYPE
 ################################
 ifeq ($(TYPE), executable)
+OBJ += $(MAIN_OBJ)
 FLAGS += -DUSE_PNG -DFUNC_TIME_MEASUREMENT
+LDFLAGS +=
 NAME := lm_$(ARCH).elf
 LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
 endif
 
 ifeq ($(TYPE), dynamic)
+OBJ += $(LIB_OBJ)
 FLAGS += -fPIC -fvisibility=hidden
+LDFLAGS += -shared
 NAME := libdlk_$(ARCH).so
 LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
 endif
 
 ifeq ($(TYPE), static)
+OBJ += $(LIB_OBJ)
 FLAGS += -fPIC -fvisibility=hidden
+LDFLAGS +=
 NAME := libdlk_$(ARCH).a
 LINK := $(AR) $(ARFLAGS) $(NAME) $(OBJ)
 endif

--- a/blueoil/converter/templates/Makefile
+++ b/blueoil/converter/templates/Makefile
@@ -92,7 +92,7 @@ clean:
 
 
 # Base Settings
-FLAGS := -I./include -O3 -std=c++14 -g -MMD -MP
+CXXFLAGS := -I./include -O3 -std=c++14 -g -MMD -MP
 ARFLAGS := -rcs
 LDFLAGS += -pthread -ldl
 
@@ -102,31 +102,31 @@ LDFLAGS += -pthread -ldl
 
 ifeq ($(ARCH), x86)
 CPU := cpu_x86
-FLAGS +=
+CXXFLAGS +=
 OBJ := $(LIB_X86_OBJ)
 endif
 
 ifeq ($(ARCH), x86_avx)
 CPU := cpu_x86
-FLAGS += -mavx2 -mfma -DUSE_AVX -fopenmp
+CXXFLAGS += -mavx2 -mfma -DUSE_AVX -fopenmp
 OBJ := $(LIB_X86_AVX_OBJ)
 endif
 
 ifeq ($(ARCH), aarch64)
 CPU := cpu_aarch64
-FLAGS +=
+CXXFLAGS +=
 OBJ := $(LIB_AARCH64_OBJ)
 endif
 
 ifeq ($(ARCH), arm)
 CPU := cpu_arm
-FLAGS +=
+CXXFLAGS +=
 OBJ := $(LIB_ARM_OBJ)
 endif
 
 ifeq ($(ARCH), fpga)
 CPU := cpu_arm
-FLAGS += -DRUN_ON_FPGA
+CXXFLAGS += -DRUN_ON_FPGA
 OBJ := $(LIB_FPGA_OBJ)
 endif
 
@@ -135,19 +135,19 @@ endif
 ################################
 ifeq ($(CPU), cpu_x86)
 CXX := g++
-FLAGS +=
+CXXFLAGS +=
 AR = ar
 endif
 
 ifeq ($(CPU), cpu_aarch64)
 CXX := aarch64-linux-gnu-g++
-FLAGS += -DUSE_NEON -fopenmp
+CXXFLAGS += -DUSE_NEON -fopenmp
 AR = aarch64-linux-gnu-ar
 endif
 
 ifeq ($(CPU), cpu_arm)
 CXX := arm-linux-gnueabihf-g++
-FLAGS += -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fopenmp
+CXXFLAGS += -DUSE_NEON -DAARCH32 -mcpu=cortex-a9 -mfpu=neon -mthumb -fopenmp
 AR = arm-linux-gnueabihf-ar
 endif
 
@@ -156,23 +156,23 @@ endif
 ################################
 ifeq ($(TYPE), executable)
 OBJ += $(MAIN_OBJ)
-FLAGS += -DUSE_PNG -DFUNC_TIME_MEASUREMENT
+CXXFLAGS += -DUSE_PNG -DFUNC_TIME_MEASUREMENT
 LDFLAGS +=
 NAME := lm_$(ARCH).elf
-LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
+LINK := $(CXX) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
 endif
 
 ifeq ($(TYPE), dynamic)
 OBJ += $(LIB_OBJ)
-FLAGS += -fPIC -fvisibility=hidden
+CXXFLAGS += -fPIC -fvisibility=hidden
 LDFLAGS += -shared
 NAME := libdlk_$(ARCH).so
-LINK := $(CXX) $(FLAGS) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
+LINK := $(CXX) $(OBJ) -o $(NAME) $(CXXFLAGS) $(LDFLAGS)
 endif
 
 ifeq ($(TYPE), static)
 OBJ += $(LIB_OBJ)
-FLAGS += -fPIC -fvisibility=hidden
+CXXFLAGS += -fPIC -fvisibility=hidden
 LDFLAGS +=
 NAME := libdlk_$(ARCH).a
 LINK := $(AR) $(ARFLAGS) $(NAME) $(OBJ)
@@ -187,8 +187,8 @@ $(NAME): $(OBJ)
 	$(LINK)
 
 %.o: %.S
-	$(CXX) $(FLAGS) -c $< -o $@ $(CXXFLAGS)
+	$(CXX) -c $< -o $@ $(CXXFLAGS)
 
 %.o: %.cpp
-	$(CXX) $(FLAGS) -c $< -o $@ $(CXXFLAGS)
+	$(CXX) -c $< -o $@ $(CXXFLAGS)
 

--- a/tests/converter/test_binary.py
+++ b/tests/converter/test_binary.py
@@ -35,7 +35,8 @@ class TestBinary(TestCaseDLKBase):
             'lmnet_quantize_cifar10')
         output_path = self.build_dir
         project_name = 'test_binary'
-        bin_name = 'lm_x86'
+        arch_name = 'x86'
+        bin_name = 'lm_' + arch_name
         project_dir = os.path.join(output_path, project_name + '.prj')
         generated_bin = os.path.join(project_dir, bin_name + '.elf')
         input_dir_path = os.path.abspath(os.path.join(os.getcwd(), model_path))
@@ -62,7 +63,7 @@ class TestBinary(TestCaseDLKBase):
                       join(project_dir, "make_clean.err"),
                       self)
 
-        run_and_check(['make', bin_name, '-j8'],
+        run_and_check(['make', 'build', 'ARCH=' + arch_name, 'TYPE=executable', '-j8'],
                       project_dir,
                       join(project_dir, "make.out"),
                       join(project_dir, "make.err"),

--- a/tests/converter/test_code_generation.py
+++ b/tests/converter/test_code_generation.py
@@ -364,7 +364,7 @@ class TestCodeGenerationBase(TestCaseDLKBase):
                       self
                       )
 
-        run_and_check(['make', 'lib_' + lib_base_name, '-j8'],
+        run_and_check(['make', 'build', 'ARCH=' + lib_base_name, 'TYPE=dynamic', '-j8'],
                       project_dir,
                       join(output_path, "make.out"),
                       join(output_path, "make.err"),


### PR DESCRIPTION
## What this patch does to fix the issue.
* This patch cleans up Makefile of runtime
* This enables easier way to add the new supported architecture
* The options for make is also changed
* This add new feature and it can detect changed header file correctly

## Link to any relevant issues or pull requests.
Fix #1006 