### PR TITLE
Add specification to blueoil document index.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,4 +16,5 @@ Blueoil -- An efficient neural network generator
    faq/index
    converter/index
    quantize/index
+   specification/index
    autoapi/index

--- a/docs/specification/index.rst
+++ b/docs/specification/index.rst
@@ -1,0 +1,11 @@
+*************
+Specification
+*************
+
+Welcome to Blueoil Specification documentation.
+
+.. toctree::
+   :maxdepth: 1
+
+   network
+   output_data


### PR DESCRIPTION
## What this patch does to fix the issue.
The current specification document is not included in document index. Thus, I make them accessible from index page.
## Link to any relevant issues or pull requests.
