### PR TITLE
Move support ops to the end of converter document part

### DIFF
--- a/docs/converter/index.rst
+++ b/docs/converter/index.rst
@@ -13,7 +13,7 @@ Converter is a converter part in Blueoil for edge devices.
    :maxdepth: 1
 
    overview
-   supported_ops
    auto_script
    shared_library
    archive_file
+   supported_ops


### PR DESCRIPTION
## What this patch does to fix the issue.
The support ops document appears in between the converter document.
This commit moves support ops to the end of the converter document part.

## Link to any relevant issues or pull requests.
