### PR TITLE
Install liblzma-dev in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     libncurses5-dev \
     libncursesw5-dev \
+    liblzma-dev \
     xz-utils \
     tk-dev \
     g++-9 \


### PR DESCRIPTION
## What this patch does to fix the issue.
To suppress the following warning.
```
/usr/local/pyenv/versions/3.6.3/envs/python3.6/lib/python3.6/site-packages/pandas/compat/__init__.py:117: 
UserWarning: Could not import the lzma module. Your installed Python is incomplete. Attempting to use lzma compression will result in a RuntimeError.
```
