### PR TITLE
Remove deprecated properties from dataset class

### DIFF
--- a/blueoil/datasets/bdd100k.py
+++ b/blueoil/datasets/bdd100k.py
@@ -53,7 +53,7 @@ class BDD100KObjectDetection(ObjectDetectionBase):
         num_max_boxes = 0
 
         for subset in cls.available_subsets:
-            obj = cls(subset=subset, base_path=base_path, is_shuffle=False)
+            obj = cls(subset=subset, base_path=base_path)
             gt_boxes_list = obj.bboxs
 
             subset_max = max([len(gt_boxes) for gt_boxes in gt_boxes_list])
@@ -74,23 +74,13 @@ class BDD100KObjectDetection(ObjectDetectionBase):
 
     def __init__(self,
                  subset="train",
-                 is_shuffle=True,
-                 enable_prefetch=False,
                  max_boxes=100,
-                 num_workers=None,
                  *args,
                  **kwargs):
 
         super().__init__(subset=subset, *args, **kwargs)
 
-        if enable_prefetch:
-            self.use_prefetch = True
-        else:
-            self.use_prefetch = False
-
-        self.is_shuffle = is_shuffle
         self.max_boxes = max_boxes
-        self.num_workers = num_workers
 
         subset_dir = "train" if subset == "train" else "val"
         self.img_dir = os.path.join(self.data_dir, "images", "100k", subset_dir)

--- a/blueoil/datasets/delta_mark.py
+++ b/blueoil/datasets/delta_mark.py
@@ -23,7 +23,7 @@ import pandas as pd
 from blueoil import data_processor
 from blueoil.datasets.base import Base, ObjectDetectionBase, StoragePathCustomizable
 from blueoil.utils.image import load_image
-from blueoil.utils.random import shuffle, train_test_split
+from blueoil.utils.random import train_test_split
 
 
 @functools.lru_cache(maxsize=None)
@@ -70,7 +70,6 @@ class DeltaMarkMixin():
 
     def __init__(
             self,
-            is_shuffle=True,
             json_file="json/annotation.json",
             image_dir="images",
             *args,
@@ -82,31 +81,10 @@ class DeltaMarkMixin():
             **kwargs,
         )
 
-        self.is_shuffle = is_shuffle
-
         self.path = {
             "json": os.path.join(self.data_dir, json_file),
             "dir": os.path.join(self.data_dir, image_dir)
         }
-
-    @property
-    def indices(self):
-        if not hasattr(self, "_indices"):
-            if self.subset == "train" and self.is_shuffle:
-                self._indices = shuffle(range(self.num_per_epoch), seed=self.seed)
-            else:
-                self._indices = list(range(self.num_per_epoch))
-
-        return self._indices
-
-    def _get_index(self, counter):
-        return self.indices[counter]
-
-    def _shuffle(self):
-        if self.subset == "train" and self.is_shuffle:
-            self._indices = shuffle(range(self.num_per_epoch), seed=self.seed)
-            print("Shuffle {} train dataset with random seed {}.".format(self.__class__.__name__, self.seed))
-            self.seed = self.seed + 1
 
     @property
     def classes(self):
@@ -238,7 +216,7 @@ class ObjectDetectionBase(DeltaMarkMixin, StoragePathCustomizable, ObjectDetecti
         num_max_boxes = 0
 
         for subset in cls.available_subsets:
-            obj = cls(subset=subset, is_shuffle=False)
+            obj = cls(subset=subset)
             _, gt_boxes_list = obj.files_and_annotations
 
             subset_max = max([len(gt_boxes) for gt_boxes in gt_boxes_list])

--- a/blueoil/datasets/image_folder.py
+++ b/blueoil/datasets/image_folder.py
@@ -45,13 +45,10 @@ class ImageFolderBase(StoragePathCustomizable, Base):
 
     def __init__(
             self,
-            is_shuffle=True,
             *args,
             **kwargs
     ):
         super().__init__(*args, **kwargs)
-
-        self.is_shuffle = is_shuffle
 
     @property
     @functools.lru_cache(maxsize=None)

--- a/blueoil/datasets/open_images_v4.py
+++ b/blueoil/datasets/open_images_v4.py
@@ -37,13 +37,10 @@ class OpenImagesV4(Base):
 
     def __init__(
             self,
-            is_shuffle=True,
             *args,
             **kwargs
     ):
         super().__init__(*args, **kwargs)
-
-        self.is_shuffle = is_shuffle
 
     @property
     def class_descriptions_csv(self):
@@ -179,7 +176,7 @@ class OpenImagesV4BoundingBox(OpenImagesV4, ObjectDetectionBase):
         num_max_boxes = 0
 
         for subset in cls.available_subsets:
-            obj = cls(subset=subset, is_shuffle=False)
+            obj = cls(subset=subset)
             _, gt_boxes_list = obj.files_and_annotations
 
             subset_max = max([len(gt_boxes) for gt_boxes in gt_boxes_list])

--- a/blueoil/datasets/pascalvoc_2007_2012.py
+++ b/blueoil/datasets/pascalvoc_2007_2012.py
@@ -57,7 +57,7 @@ class Pascalvoc20072012(ObjectDetectionBase):
         num_max_boxes = 0
 
         for subset in cls.available_subsets:
-            obj = cls(subset=subset, is_shuffle=False, skip_difficult=skip_difficult)
+            obj = cls(subset=subset, skip_difficult=skip_difficult)
             gt_boxes_list = obj.annotations
 
             subset_max = max([len(gt_boxes) for gt_boxes in gt_boxes_list])
@@ -70,7 +70,6 @@ class Pascalvoc20072012(ObjectDetectionBase):
             self,
             subset="train",
             is_standardize=True,
-            is_shuffle=True,
             skip_difficult=True,
             *args,
             **kwargs
@@ -82,7 +81,6 @@ class Pascalvoc20072012(ObjectDetectionBase):
         )
 
         self.is_standardize = is_standardize
-        self.is_shuffle = is_shuffle
         self.skip_difficult = skip_difficult
 
         self._init_files_and_annotations(*args, **kwargs)

--- a/blueoil/datasets/widerface.py
+++ b/blueoil/datasets/widerface.py
@@ -53,19 +53,11 @@ class WiderFace(ObjectDetectionBase):
 
     def __init__(self,
                  subset="train",
-                 enable_prefetch=False,
                  max_boxes=3,
-                 num_workers=8,
                  *args,
                  **kwargs):
 
-        if enable_prefetch:
-            self.use_prefetch = True
-        else:
-            self.use_prefetch = False
-
         self.max_boxes = max_boxes
-        self.num_workers = num_workers
 
         super().__init__(subset=subset,
                          *args,


### PR DESCRIPTION
## What this patch does to fix the issue.
Remove some deprecated properties from dataset class. These feature will be done in https://github.com/blue-oil/blueoil/blob/e57843009854c3b74737a841b3d6b850dab23dae/blueoil/datasets/dataset_iterator.py#L287-L363 . 
## Link to any relevant issues or pull requests.
