### PR TITLE
Add PerImageStandardization compatibility in (C++ inference) runtime

### DIFF
--- a/runtime/include/blueoil_data_processor.hpp
+++ b/runtime/include/blueoil_data_processor.hpp
@@ -34,6 +34,8 @@ Tensor Resize(const Tensor& image, const std::pair<int, int>& size);
 
 Tensor DivideBy255(const Tensor& image);
 
+Tensor PerImageStandardization(const Tensor& image);
+
 // post process.
 
 Tensor FormatYoloV2(const Tensor& input,

--- a/runtime/src/blueoil.cpp
+++ b/runtime/src/blueoil.cpp
@@ -266,7 +266,11 @@ void MappingProcess(const YAML::Node processors_node, std::vector<Processor>* fu
             Processor tmp = std::move(data_processor::DivideBy255);
             functions->push_back(std::move(tmp));
 
-          } else if (method_name == "Resize" || method_name == "ResizeWithGtBoxes") {
+          } else if (method_name == "PerImageStandardization") {
+            Processor tmp = std::move(data_processor::PerImageStandardization);
+            functions->push_back(std::move(tmp));
+
+          }else if (method_name == "Resize" || method_name == "ResizeWithGtBoxes") {
             std::pair<int, int> size = method_params["size"].as<std::pair<int, int>>();
             Processor tmp = std::bind(data_processor::Resize, std::placeholders::_1, size);
             functions->push_back(std::move(tmp));


### PR DESCRIPTION
## What this patch does to fix the issue.
The PerImageStandardization is already implemented but it is not in the mapping process.
This PR adds mapping process node to functions vector.

## Link to any relevant issues or pull requests.
https://github.com/blue-oil/blueoil/issues/1020#issuecomment-628419387