### PR TITLE
[WIP] Allow only 1 connection to avoid parallel inference requests for demo

### DIFF
--- a/output_template/python/motion_jpeg_server_from_camera.py
+++ b/output_template/python/motion_jpeg_server_from_camera.py
@@ -24,7 +24,6 @@ from multiprocessing import Pool
 import os
 import signal
 import sys
-from SocketServer import ThreadingMixIn
 
 import click
 
@@ -114,10 +113,6 @@ class MotionJpegHandler(BaseHTTPRequestHandler):
         return
 
 
-class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-    daemon_threads = True
-
-
 def _run_inference(inputs):
     global nn, pre_process, post_process
     res, fps, fps_only_network = run_inference(inputs, nn, pre_process, post_process)
@@ -168,7 +163,7 @@ def run(model, config_file, port=80):
     pool = Pool(processes=1, initializer=_init_worker)
 
     try:
-        server = ThreadedHTTPServer(('', port), MotionJpegHandler)
+        server = HTTPServer(('', port), MotionJpegHandler)
         print("server starting")
         server.serve_forever()
     except KeyboardInterrupt as e:


### PR DESCRIPTION
## What this patch does to fix the issue.
Avoid #1028 for demonstration script (FPGA will be stuck with parallel inference and cannot recover without rebooting).

* Before this PR
See the video(only for reviewer): 
Threading allows multi requests. If requests are coming at the same time, FPGA will be stuck and cannot recover this state without rebooting DE10-Nano 😭 

* After this PR
See the video(only for reviewer): 
The inference will not be run as parallel even if requests are many. Safe for FPGA 😄😄😄 

## Link to any relevant issues or pull requests.
