### PR TITLE
Rewrote config module for inference.

### DIFF
--- a/output_template/python/config.py
+++ b/output_template/python/config.py
@@ -25,6 +25,17 @@ from blueoil import post_processor, pre_processor
 
 
 def load_yaml(config_file):
+    """Load meta.yaml that is output when the model is converted.
+
+    Args:
+        config_file (str): Path of the configuration file.
+
+    Returns:
+        EasyDict: Dictionary object of loaded configuration file.
+
+    Examples:
+        >>> config = load_yaml("/path/of/meta.yaml")
+    """
     with open(config_file) as config_file_stream:
         config = yaml.load(config_file_stream, Loader=yaml.Loader)
     # use only upper key.
@@ -32,10 +43,60 @@ def load_yaml(config_file):
 
 
 def build_pre_process(pre_processor_config):
+    """The pre processor is loaded based on the information passed,
+    It is append to a Sequence object and returned in.
+
+    Args:
+        pre_processor_config (List[Dict[str, Optional[Dict[str, Any]]]]): List of processors to load.
+
+    Returns:
+        Sequence: A Sequence object with a list of processors inside.
+
+    Examples:
+        >>> config = [
+                {"Resize": {"size": [128, 128], "resample": "NEAREST"}},
+                {"PerImageStandardization": None},
+            ]
+        >>> pre_processors = build_pre_process(config)
+    """
     return _build_process(pre_processor, pre_processor_config)
 
 
 def build_post_process(post_processor_config):
+    """The post processor is loaded based on the information passed,
+    It is append to a Sequence object and returned in.
+
+    Args:
+        post_processor_config (List[Dict[str, Optional[Dict[str, Any]]]]): List of processors to load.
+
+    Returns:
+        Sequence: A Sequence object with a list of processors inside.
+
+    Examples:
+        >>> config = [
+                {"FormatYoloV2": {
+                    "anchors": [
+                        [1.3221, 1.73145],
+                        [3.19275, 4.00944],
+                        [5.05587, 8.09892],
+                        [9.47112, 4.84053],
+                        [11.2364, 10.0071],
+                    ],
+                    "boxes_per_cell": 5,
+                    "data_format": "NHWC",
+                    "image_size": [128, 128],
+                    "num_classes": 1,
+                }},
+                {"ExcludeLowScoreBox": {"threshold": 0.3}},
+                {"NMS": {
+                    "classes": ["person"],
+                    "iou_threshold": 0.5,
+                    "max_output_size": 100,
+                    "per_class": True,
+                }},
+            ]
+        >>> post_processors = build_post_process(config)
+    """
     return _build_process(post_processor, post_processor_config)
 
 

--- a/output_template/python/config.py
+++ b/output_template/python/config.py
@@ -105,9 +105,9 @@ def _build_process(module, processor_config=None):
     processor_config = processor_config or []
     for p in processor_config:
         for class_name, kwargs in p.items():
-            try:
+            if hasattr(module, class_name):
                 cls = getattr(module, class_name)
-            except AttributeError:
+            else:
                 cls = import_from_string(class_name)
 
             processor = cls.__new__(cls)
@@ -137,15 +137,15 @@ def import_from_string(import_string):
     except ImportError:
         pass
 
-    try:
+    if "." in import_string:
         module_name, attr_name = import_string.rsplit(".", 1)
-    except ValueError:
+    else:
         raise ImportError("Invalid import string '{}'".format(import_string))
 
     module = import_module(module_name)
-    try:
+    if hasattr(module, attr_name):
         return getattr(module, attr_name)
-    except AttributeError:
-        raise ImportError("There is no attribute name '{}' in module '{}'".format(
-            module_name, attr_name,
-        ))
+
+    raise ImportError("There is no attribute name '{}' in module '{}'".format(
+        module_name, attr_name,
+    ))

--- a/output_template/python/config.py
+++ b/output_template/python/config.py
@@ -137,15 +137,14 @@ def import_from_string(import_string):
     except ImportError:
         pass
 
-    if "." in import_string:
-        module_name, attr_name = import_string.rsplit(".", 1)
-    else:
+    if "." not in import_string:
         raise ImportError("Invalid import string '{}'".format(import_string))
 
+    module_name, attr_name = import_string.rsplit(".", 1)
     module = import_module(module_name)
-    if hasattr(module, attr_name):
-        return getattr(module, attr_name)
+    if not hasattr(module, attr_name):
+        raise ImportError("There is no attribute name '{}' in module '{}'".format(
+            module_name, attr_name,
+        ))
 
-    raise ImportError("There is no attribute name '{}' in module '{}'".format(
-        module_name, attr_name,
-    ))
+    return getattr(module, attr_name)


### PR DESCRIPTION
## What this patch does to fix the issue.

#1026

## Modified part

* Deleted because the imp module is deprecated.
* The duplicated process is made into a function and the implementation is simplified.
* Changed to can load custom processor.

## How to load custom processor

It is now possible to specify an import path for Pre / Post Processor in meta.yaml.

```yaml
POST_PROCESSOR:
  - blueoil.post_processor.FormatCenterNet:
      image_size: [160, 256]
      num_classes: 1
      down_ratio: 2
      top_k_results_output: 50
      use_offset: false
      data_format: NHWC

PRE_PROCESSOR:
  - blueoil.pre_processor.ResizeWithGtBoxes:
      size: [160, 256]
  - DivideBy255: null
```