### PR TITLE
tf_upgrade_v2 for network/base.py

### DIFF
--- a/blueoil/networks/base.py
+++ b/blueoil/networks/base.py
@@ -140,7 +140,7 @@ class BaseNetwork(object):
             learning_rate = self.optimizer_kwargs["learning_rate"]
 
         else:
-            if self.learning_rate_func is tf.train.piecewise_constant:
+            if self.learning_rate_func is tf.compat.v1.train.piecewise_constant:
                 learning_rate = self.learning_rate_func(
                     x=self.global_step,
                     **self.learning_rate_kwargs
@@ -166,7 +166,7 @@ class BaseNetwork(object):
         # TODO(wenhao): revert when support `tf.layers.batch_normalization`
         # update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
         # with tf.control_dependencies(update_ops):
-        with tf.name_scope("train"):
+        with tf.compat.v1.name_scope("train"):
             if var_list == []:
                 var_list = tf.compat.v1.trainable_variables()
 


### PR DESCRIPTION
## What this patch does to fix the issue.

I converted only the blueoil/network/base.py with the command line tool tf_upgrade_v2 to run on tensorflow2 because there are a lot of targets in the network folder.

Here's what I did:

install newest tenosrflow (tensorflow-gpu==1.5.2)
Run the upgrade script tf_upgrade_v2
Check the upgrade report for warnings and errors
Run test (make test)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade
