### PR TITLE
tf_upgrade_v2 for network/classification/lmnet_v0.py

### DIFF
--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -74,24 +74,24 @@ class LmnetV0(Base):
 
         kernel_initializer = tf.compat.v1.random_normal_initializer(mean=0.0, stddev=0.01)
         x = tf.compat.v1.layers.conv2d(name='conv7',
-                             inputs=x,
-                             filters=self.num_classes,
-                             kernel_size=1,
-                             kernel_initializer=kernel_initializer,
-                             activation=None,
-                             use_bias=True,
-                             data_format=channels_data_format)
+                                       inputs=x,
+                                       filters=self.num_classes,
+                                       kernel_size=1,
+                                       kernel_initializer=kernel_initializer,
+                                       activation=None,
+                                       use_bias=True,
+                                       data_format=channels_data_format)
 
         self._heatmap_layer = x
 
         h = x.get_shape()[1].value if self.data_format == 'NHWC' else x.get_shape()[2].value
         w = x.get_shape()[2].value if self.data_format == 'NHWC' else x.get_shape()[3].value
         x = tf.compat.v1.layers.average_pooling2d(name='pool7',
-                                        inputs=x,
-                                        pool_size=[h, w],
-                                        padding='VALID',
-                                        strides=1,
-                                        data_format=channels_data_format)
+                                                  inputs=x,
+                                                  pool_size=[h, w],
+                                                  padding='VALID',
+                                                  strides=1,
+                                                  data_format=channels_data_format)
 
         self.base_output = tf.reshape(x, [-1, self.num_classes], name='pool7_reshape')
 

--- a/blueoil/networks/classification/lmnet_v0.py
+++ b/blueoil/networks/classification/lmnet_v0.py
@@ -53,7 +53,7 @@ class LmnetV0(Base):
 
         channels_data_format = 'channels_last' if self.data_format == 'NHWC' else 'channels_first'
         _lmnet_block = self._get_lmnet_block(is_training, channels_data_format)
-        _max_pooling2d = functools.partial(tf.layers.max_pooling2d, pool_size=2, strides=2, padding='SAME',
+        _max_pooling2d = functools.partial(tf.compat.v1.layers.max_pooling2d, pool_size=2, strides=2, padding='SAME',
                                            data_format=channels_data_format)
 
         self.images = images
@@ -70,10 +70,10 @@ class LmnetV0(Base):
         x = _max_pooling2d(name='pool5', inputs=x)
         x = _lmnet_block('conv6', x, 64, 1, activation=tf.nn.relu)
 
-        x = tf.layers.dropout(x, training=is_training)
+        x = tf.compat.v1.layers.dropout(x, training=is_training)
 
-        kernel_initializer = tf.random_normal_initializer(mean=0.0, stddev=0.01)
-        x = tf.layers.conv2d(name='conv7',
+        kernel_initializer = tf.compat.v1.random_normal_initializer(mean=0.0, stddev=0.01)
+        x = tf.compat.v1.layers.conv2d(name='conv7',
                              inputs=x,
                              filters=self.num_classes,
                              kernel_size=1,
@@ -86,7 +86,7 @@ class LmnetV0(Base):
 
         h = x.get_shape()[1].value if self.data_format == 'NHWC' else x.get_shape()[2].value
         w = x.get_shape()[2].value if self.data_format == 'NHWC' else x.get_shape()[3].value
-        x = tf.layers.average_pooling2d(name='pool7',
+        x = tf.compat.v1.layers.average_pooling2d(name='pool7',
                                         inputs=x,
                                         pool_size=[h, w],
                                         padding='VALID',


### PR DESCRIPTION
## What this patch does to fix the issue.
I converted only the blueoil/network/classification/lmnet_v0.py with the command line tool tf_upgrade_v2 to run on tensorflow2 because there are a lot of targets in the network folder.

Here's what I did:

1. install newest tenosrflow (tensorflow-gpu==1.5.2)
2. Run the upgrade script tf_upgrade_v2
3. Check the upgrade report for warnings and errors
4. Run test (make test)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade
