### PR TITLE
use byte arrays to remove floating point number literals

### DIFF
--- a/blueoil/converter/template.py
+++ b/blueoil/converter/template.py
@@ -14,9 +14,28 @@
 # limitations under the License.
 # =============================================================================
 from os import path
+import struct
 
 from jinja2 import Environment as JinjaEnv
 from jinja2 import FileSystemLoader
+import numpy as np
+
+
+def pack_to_bytes(a):
+    t = type(a)
+    if t == float or t == np.float32:
+        packed_binary = struct.pack("<f", a)
+    elif t == int or t == np.int32:
+        packed_binary = struct.pack("<i", a)
+    elif t == np.int64:
+        packed_binary = struct.pack("<q", a)
+    elif t == np.uint32:
+        packed_binary = struct.pack("<I", a)
+
+    if t == np.int64:
+        return ",".join(map(str, list(struct.unpack("BBBBBBBB", packed_binary))))
+    else:
+        return ",".join(map(str, list(struct.unpack("BBBB", packed_binary))))
 
 
 class Template(object):
@@ -59,5 +78,6 @@ class Template(object):
     def _create_jinja(self):
         loader = FileSystemLoader(self.root_dir, encoding='utf8')
         jinja = JinjaEnv(loader=loader)
+        jinja.globals['pack_to_bytes'] = pack_to_bytes
 
         return jinja

--- a/blueoil/converter/templates/manual/consts/input.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/input.tpl.cpp
@@ -20,9 +20,9 @@ limitations under the License.
 {% if node.transposed_data %}
 
 #ifdef RUN_ON_FPGA
-static Base<{{ node.dtype.cpptype() }}>::type {{ node.name }}_raw[] = {
+alignas(4) static unsigned char {{ node.name }}_raw[] = {
   {% for d in node.transposed_data -%}
-  {{- d -}},
+  {{- pack_to_bytes(d) -}},
   {%- endfor %}
 };
 static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{ node.name }}_shape = {
@@ -33,10 +33,11 @@ static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{
 const TensorView<{{ node.dtype.cpptype() }}, MemoryLayout::{{ node.transposed_dimension_format }}> {{ node.name }}_output(
     reinterpret_cast<{{ node.dtype.cpptype() }}*>({{ node.name }}_raw),
     {{ node.name }}_shape);
+
 #elif defined USE_NEON || defined USE_AVX
-static Base<{{ node.dtype.cpptype() }}>::type {{ node.name }}_raw[] = {
+alignas(4) static unsigned char {{ node.name }}_raw[] = {
   {% for d in node.data.flatten() -%}
-  {{- d -}},
+  {{- pack_to_bytes(d) -}},
   {%- endfor %}
 };
 static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{ node.name }}_shape = {
@@ -47,10 +48,11 @@ static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{
 const TensorView<{{ node.dtype.cpptype() }}, MemoryLayout::{{ node.dimension }}> {{ node.name }}_output(
     reinterpret_cast<{{ node.dtype.cpptype() }}*>({{ node.name }}_raw),
     {{ node.name }}_shape);
+
 #else
-static Base<{{ node.dtype.cpptype() }}>::type {{ node.name }}_raw[] = {
+static unsigned char {{ node.name }}_raw[] = {
   {% for d in node.kn2row_data -%}
-  {{- d -}},
+  {{- pack_to_bytes(d) -}},
   {%- endfor %}
 };
 static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{ node.name }}_shape = {
@@ -65,9 +67,9 @@ const TensorView<{{ node.dtype.cpptype() }}, MemoryLayout::{{ node.kn2row_dimens
 
 {% else -%}
 
-static Base<{{ node.dtype.cpptype() }}>::type {{ node.name }}_raw[] = {
+static unsigned char {{ node.name }}_raw[] = {
   {% for d in node.data.flatten() -%}
-  {{- d -}},
+  {{- pack_to_bytes(d) -}},
   {%- endfor %}
 };
 static constexpr decltype({{ node.name }}_output)::tensor_info_t<std::size_t> {{ node.name }}_shape = {

--- a/blueoil/converter/templates/manual/consts/scaling_factors.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/scaling_factors.tpl.cpp
@@ -22,15 +22,19 @@ namespace scaling_factors {
 
 {% if conv.quantizer.op_type == 'BinaryMeanScalingQuantizer' -%}
 
-T_FLOAT {{ conv.name }} = {{ conv.quantizer.scaling_factor }};
+alignas(4) unsigned char {{ conv.name }}_raw[] = { {{ pack_to_bytes(conv.quantizer.scaling_factor) }} };
+
+T_FLOAT {{ conv.name }} = *(reinterpret_cast<float*>({{ conv.name }}_raw));
 
 {% elif conv.quantizer.op_type == 'BinaryChannelWiseMeanScalingQuantizer' -%}
 
-T_FLOAT {{ conv.name }}[{{ conv.depth }}] = {
+alignas(4) unsigned char {{ conv.name }}_raw[] = {
   {% for f in conv.quantizer.scaling_factor -%}
-  {{- f -}},
+  {{- pack_to_bytes(f) -}},
   {%- endfor %}
 };
+
+T_FLOAT* {{ conv.name }} = reinterpret_cast<float*>({{ conv.name }}_raw);
 
 {% else -%}
 

--- a/blueoil/converter/templates/manual/consts/scaling_factors.tpl.h
+++ b/blueoil/converter/templates/manual/consts/scaling_factors.tpl.h
@@ -28,7 +28,7 @@ extern T_FLOAT {{ conv.name }};
 
 {% elif conv.quantizer.op_type == 'BinaryChannelWiseMeanScalingQuantizer' -%}
 
-extern T_FLOAT {{ conv.name }}[{{ conv.depth }}];
+extern T_FLOAT* {{ conv.name }};
 
 {% else -%}
 


### PR DESCRIPTION
## What this patch does to fix the issue.

Conversion between floating point value :left_right_arrow: decimal string representation cause some small error.

In this pull request, I removed floating point number literals. Instead, parameters are represented as an array of unsigned char, then casted to floating point number by `reinterpret_cast`.

## Link to any relevant issues or pull requests.

fix #1078
