### PR TITLE
tf_upgrade_v2 for networks/classification/quantize_example.py

### DIFF
--- a/blueoil/networks/classification/quantize_example.py
+++ b/blueoil/networks/classification/quantize_example.py
@@ -23,19 +23,19 @@ class SampleNetwork(Base):
         with tf.compat.v1.variable_scope("block_1"):
             conv = conv2d("conv", self.inputs, filters=32, kernel_size=3,
                           activation=None, use_bias=False, data_format=channel_data_format,
-                          kernel_initializer=tf.contrib.layers.variance_scaling_initializer())
+                          kernel_initializer=tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0))
             batch_normed = batch_norm("bn", conv, is_training=is_training, decay=0.99, scale=True, center=True,
                                       data_format=self.data_format)
             self.block_1 = self.activation(batch_normed)
 
         self.block_last = conv2d("block_last", self.block_1, filters=self.num_classes, kernel_size=1,
                                  activation=None, use_bias=True, is_debug=self.is_debug,
-                                 kernel_initializer=tf.random_normal_initializer(mean=0.0, stddev=0.01),
+                                 kernel_initializer=tf.compat.v1.random_normal_initializer(mean=0.0, stddev=0.01),
                                  data_format=channel_data_format)
 
         h = self.block_last.get_shape()[1].value
         w = self.block_last.get_shape()[2].value
-        self.pool = tf.layers.average_pooling2d(name='global_average_pool', inputs=self.block_last,
+        self.pool = tf.compat.v1.layers.average_pooling2d(name='global_average_pool', inputs=self.block_last,
                                                 pool_size=[h, w], padding='VALID', strides=1,
                                                 data_format=channel_data_format)
         self.base_output = tf.reshape(self.pool, [-1, self.num_classes], name="pool_reshape")

--- a/blueoil/networks/classification/quantize_example.py
+++ b/blueoil/networks/classification/quantize_example.py
@@ -36,8 +36,8 @@ class SampleNetwork(Base):
         h = self.block_last.get_shape()[1].value
         w = self.block_last.get_shape()[2].value
         self.pool = tf.compat.v1.layers.average_pooling2d(name='global_average_pool', inputs=self.block_last,
-                                                pool_size=[h, w], padding='VALID', strides=1,
-                                                data_format=channel_data_format)
+                                                          pool_size=[h, w], padding='VALID', strides=1,
+                                                          data_format=channel_data_format)
         self.base_output = tf.reshape(self.pool, [-1, self.num_classes], name="pool_reshape")
 
         return self.base_output


### PR DESCRIPTION
## What this patch does to fix the issue.
I converted the blueoil/network/classification/quantize_example.py with the command line tool tf_upgrade_v2 to run on tensorflow2.

Here's what I did:

1. install newest tenosrflow (tensorflow-gpu==1.5.2)
2. Run the upgrade script tf_upgrade_v2
3. Check the upgrade report for warnings and errors
4. Run test (make test)

## Link to any relevant issues or pull requests.
* #479 
* https://www.tensorflow.org/guide/upgrade
