### PR TITLE
Remove YouTube Faces format from keypoint detection tutorial.

### DIFF
--- a/docs/tutorial/image_keypoint_detection.md
+++ b/docs/tutorial/image_keypoint_detection.md
@@ -11,9 +11,8 @@ The COCO dataset is available from the official website.
 Although COCO dataset is for multi-person pose estimation challenge track.
 We customize this dataset to train a single-person pose estimation task.
 
-Blueoil supports 2 formats for keypoint detection.
+Blueoil supports only 1 format for keypoint detection.
 - MSCOCO format
-- YouTube Faces format
 
 For details, please refer to **MSCOCO_2017 keypoint detection** section in <a href="../usage/dataset.html">Prepare training dataset</a>
 


### PR DESCRIPTION
## What this patch does to fix the issue.
Remove YouTube Faces format from keypoint detection tutorial. 
Because keypoint detection can only choose one data format.
```
[?] choose dataset format: Mscoco for Single-Person Pose Estimation
 > Mscoco for Single-Person Pose Estimation
```
## Link to any relevant issues or pull requests.
