### PR TITLE
Fix checking pad

### DIFF
--- a/blueoil/converter/core/operators.py
+++ b/blueoil/converter/core/operators.py
@@ -1041,8 +1041,8 @@ class Conv(Operator):
             mW += f'\nThe weight format is {self._input_ops["W"].dimension}.'
             self._assert(in_W == self.kernel_width, mW)
         if self.kernel_index_H is not None and self.index_H is not None:
-            pad_H = self.pads[self.kernel_index_H] + \
-                self.pads[self.kernel_index_H + self._num_dimensions]
+            pad_H = self.pads[self.kernel_index_H * 2] + \
+                self.pads[self.kernel_index_H * 2 + 1]
             stride_H = self.strides[self.kernel_index_H]
             dilation_H = self.dilations[self.kernel_index_H]
             # print(self.name, ' input dimension: ', self.input_ops['X'].dimension)
@@ -1068,8 +1068,8 @@ class Conv(Operator):
                 print(f'mispadding height at {self.name}: {output_H_rest}')
 
         if self.kernel_index_W is not None and self.index_W is not None:
-            pad_W = self.pads[self.kernel_index_W] + \
-                self.pads[self.kernel_index_W + self._num_dimensions]
+            pad_W = self.pads[self.kernel_index_W * 2] + \
+                self.pads[self.kernel_index_W * 2 + 1]
             stride_W = self.strides[self.kernel_index_W]
             dilation_W = self.dilations[self.kernel_index_W]
             # print(self.name, ' input shape: ', self.input_ops['X'].shape)

--- a/tests/converter/test_consistency_check.py
+++ b/tests/converter/test_consistency_check.py
@@ -114,7 +114,7 @@ class TestConsistencyCheck(unittest.TestCase):
             [1, 3, 3, 3],
             Float32(),
             input_ops,
-            pads=[1, 1, 2, 2],
+            pads=[1, 2, 1, 2],
             strides=[2, 2]
         )
 


### PR DESCRIPTION
## What this patch does to fix the issue.
correct order: `[top, bottom, left, right]`
(it is same as tf.pad)

## Link to any relevant issues or pull requests.
