### PR TITLE
Avoid Error when debug dir didn't exist

### DIFF
--- a/blueoil/converter/templates/src/network.tpl.cpp
+++ b/blueoil/converter/templates/src/network.tpl.cpp
@@ -18,6 +18,12 @@ limitations under the License.
 #include <cstring>
 #include <cstdio>
 #include <ctime>
+{% if config.debug %}
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+{% endif %}
 #include "global.h"
 #include "func/add.h"
 #include "func/average_pool.h"
@@ -226,6 +232,21 @@ bool Network::init()
 // Initialize OpenMP Thread-pool
 #pragma omp parallel
   std::cout << std::flush;
+
+  {% if config.debug -%}
+  const auto debug_path = "debug";
+  struct stat debug_dir_stat;
+  auto ret = stat(debug_path, &debug_dir_stat);
+  if (ret == -1 && errno == ENOENT) {
+    mkdir(debug_path, 0755);
+    std::cerr << "Info: debug directory is created" << std::endl;
+  } else if (S_ISDIR(debug_dir_stat.st_mode)) {
+    std::cerr << "Warning: debug directory will be overwritten" << std::endl;
+  } else {
+    std::cerr << "Error: '" << debug_path << "' is not a directory" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  {% endif -%}
 
   return true;
 }


### PR DESCRIPTION
## What this patch does to fix the issue.
Currently, when debug mode is enabled and 'debug' directory doesn't exist, runtime will cause segmentation fault.
This PR fix it and indicate useful message.

## Link to any relevant issues or pull requests.
