### PR TITLE
Fix license header consistency

### DIFF
--- a/blueoil/__init__.py
+++ b/blueoil/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/cmd/__init__.py
+++ b/blueoil/cmd/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/converter/core/__init__.py
+++ b/blueoil/converter/core/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/converter/templates/include/de10_nano.h
+++ b/blueoil/converter/templates/include/de10_nano.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #pragma once
 #include "global.h"

--- a/blueoil/converter/templates/include/dlk_test.h
+++ b/blueoil/converter/templates/include/dlk_test.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef dlk_test_nodeS_H_INCLUDED
 #define dlk_test_nodeS_H_INCLUDED

--- a/blueoil/converter/templates/include/dma_buffer.h
+++ b/blueoil/converter/templates/include/dma_buffer.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #pragma once
 #include <sys/mman.h>

--- a/blueoil/converter/templates/include/func/add.h
+++ b/blueoil/converter/templates/include/func/add.h
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_ADD_H_INCLUDED
 #define DLK_FUNC_ADD_H_INCLUDED

--- a/blueoil/converter/templates/include/func/average_pool.h
+++ b/blueoil/converter/templates/include/func/average_pool.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_AVERAGE_POOL_H_INCLUDED
 #define DLK_FUNC_AVERAGE_POOL_H_INCLUDED

--- a/blueoil/converter/templates/include/func/batch_normalization.h
+++ b/blueoil/converter/templates/include/func/batch_normalization.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_BATCH_NORMALIZATION_H_INCLUDED
 #define DLK_FUNC_BATCH_NORMALIZATION_H_INCLUDED

--- a/blueoil/converter/templates/include/func/concat_on_depth.h
+++ b/blueoil/converter/templates/include/func/concat_on_depth.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_CONCAT_ON_DEPTH_H_INCLUDED
 #define DLK_FUNC_CONCAT_ON_DEPTH_H_INCLUDED

--- a/blueoil/converter/templates/include/func/conv2d.h
+++ b/blueoil/converter/templates/include/func/conv2d.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_CONV2D_H_INCLUDED
 #define DLK_FUNC_CONV2D_H_INCLUDED

--- a/blueoil/converter/templates/include/func/depth_to_space.h
+++ b/blueoil/converter/templates/include/func/depth_to_space.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_DEPTH_TO_SPACE_H_INCLUDED
 #define DLK_FUNC_DEPTH_TO_SPACE_H_INCLUDED

--- a/blueoil/converter/templates/include/func/extract_image_patches.h
+++ b/blueoil/converter/templates/include/func/extract_image_patches.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_EXTRACT_IMAGE_PATCHES
 #define DLK_FUNC_EXTRACT_IMAGE_PATCHES

--- a/blueoil/converter/templates/include/func/impl/apply_thresholds.h
+++ b/blueoil/converter/templates/include/func/impl/apply_thresholds.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_APPLY_THRESHOLDS_H_INCLUDED
 #define DLK_FUNC_IMPL_APPLY_THRESHOLDS_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/binary_op.h
+++ b/blueoil/converter/templates/include/func/impl/binary_op.h
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_BINARY_OP_H_INCLUDED
 #define DLK_FUNC_IMPL_BINARY_OP_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/pack_16bit.h
+++ b/blueoil/converter/templates/include/func/impl/pack_16bit.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 

--- a/blueoil/converter/templates/include/func/impl/pop_count.h
+++ b/blueoil/converter/templates/include/func/impl/pop_count.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_POP_COUNT_H_INCLUDED
 #define DLK_FUNC_IMPL_POP_COUNT_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/quantized_conv2d_accelerator.h
+++ b/blueoil/converter/templates/include/func/impl/quantized_conv2d_accelerator.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_QUANTIZED_CONV2D_ACCELERATOR_H_INCLUDED
 #define DLK_FUNC_IMPL_QUANTIZED_CONV2D_ACCELERATOR_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/quantized_conv2d_kn2row.h
+++ b/blueoil/converter/templates/include/func/impl/quantized_conv2d_kn2row.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_QUANTIZED_CONV2D_KN2ROW_H_INCLUDED
 #define DLK_FUNC_IMPL_QUANTIZED_CONV2D_KN2ROW_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/quantized_conv2d_tiling.h
+++ b/blueoil/converter/templates/include/func/impl/quantized_conv2d_tiling.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_QUANTIZED_CONV2D_TILING_H_INCLUDED
 #define DLK_FUNC_IMPL_QUANTIZED_CONV2D_TILING_H_INCLUDED

--- a/blueoil/converter/templates/include/func/impl/unary_op.h
+++ b/blueoil/converter/templates/include/func/impl/unary_op.h
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_IMPL_UNARY_OP_H_INCLUDED
 #define DLK_FUNC_IMPL_UNARY_OP_H_INCLUDED

--- a/blueoil/converter/templates/include/func/leaky_relu.h
+++ b/blueoil/converter/templates/include/func/leaky_relu.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_LEAKY_RELU_H_INCLUDED
 #define DLK_FUNC_LEAKY_RELU_H_INCLUDED

--- a/blueoil/converter/templates/include/func/lookup.h
+++ b/blueoil/converter/templates/include/func/lookup.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_LOOKUP_H_INCLUDED
 #define DLK_FUNC_LOOKUP_H_INCLUDED

--- a/blueoil/converter/templates/include/func/matmul.h
+++ b/blueoil/converter/templates/include/func/matmul.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_MATMUL_H_INCLUDED
 #define DLK_FUNC_MATMUL_H_INCLUDED

--- a/blueoil/converter/templates/include/func/max.h
+++ b/blueoil/converter/templates/include/func/max.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_MAX_H_INCLUDED
 #define DLK_FUNC_MAX_H_INCLUDED

--- a/blueoil/converter/templates/include/func/max_pool.h
+++ b/blueoil/converter/templates/include/func/max_pool.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_MAX_POOLING_H_INCLUDED
 #define DLK_FUNC_MAX_POOLING_H_INCLUDED

--- a/blueoil/converter/templates/include/func/minimum.h
+++ b/blueoil/converter/templates/include/func/minimum.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_MINIMUM_H_INCLUDED
 #define DLK_FUNC_MINIMUM_H_INCLUDED

--- a/blueoil/converter/templates/include/func/mul.h
+++ b/blueoil/converter/templates/include/func/mul.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_MUL_H_INCLUDED
 #define DLK_FUNC_MUL_H_INCLUDED

--- a/blueoil/converter/templates/include/func/pad.h
+++ b/blueoil/converter/templates/include/func/pad.h
@@ -1,3 +1,18 @@
+/* Copyright 2018 The Blueoil Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=============================================================================*/
+
 #ifndef DLK_FUNC_PAD_H_INCLUDED
 #define DLK_FUNC_PAD_H_INCLUDED
 

--- a/blueoil/converter/templates/include/func/quantized_conv2d.h
+++ b/blueoil/converter/templates/include/func/quantized_conv2d.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_QUANTIZED_CONV2D_H_INCLUDED
 #define DLK_FUNC_QUANTIZED_CONV2D_H_INCLUDED

--- a/blueoil/converter/templates/include/func/real_div.h
+++ b/blueoil/converter/templates/include/func/real_div.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_REAL_DIV_H
 #define DLK_FUNC_REAL_DIV_H

--- a/blueoil/converter/templates/include/func/relu.h
+++ b/blueoil/converter/templates/include/func/relu.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_RELU_H_INCLUDED
 #define DLK_FUNC_RELU_H_INCLUDED

--- a/blueoil/converter/templates/include/func/resize_nearest_neighbor.h
+++ b/blueoil/converter/templates/include/func/resize_nearest_neighbor.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_RESIZE_NEAREST_NEIGHBOR_H_INCLUDED
 #define DLK_FUNC_RESIZE_NEAREST_NEIGHBOR_H_INCLUDED

--- a/blueoil/converter/templates/include/func/round.h
+++ b/blueoil/converter/templates/include/func/round.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_ROUND_H_INCLUDED
 #define DLK_FUNC_ROUND_H_INCLUDED

--- a/blueoil/converter/templates/include/func/softmax.h
+++ b/blueoil/converter/templates/include/func/softmax.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_SOFTMAX_H_INCLUDED
 #define DLK_FUNC_SOFTMAX_H_INCLUDED

--- a/blueoil/converter/templates/include/func/split.h
+++ b/blueoil/converter/templates/include/func/split.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_SPLIT_H_INCLUDED
 #define DLK_FUNC_SPLIT_H_INCLUDED

--- a/blueoil/converter/templates/include/func/sqrt.h
+++ b/blueoil/converter/templates/include/func/sqrt.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_SQRT_H_INCLUDED
 #define DLK_FUNC_SQRT_H_INCLUDED

--- a/blueoil/converter/templates/include/func/sub.h
+++ b/blueoil/converter/templates/include/func/sub.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_FUNC_SUB_H_INCLUDED
 #define DLK_FUNC_SUB_H_INCLUDED

--- a/blueoil/converter/templates/include/global.tpl.h
+++ b/blueoil/converter/templates/include/global.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef GLOBAL_H
 #define GLOBAL_H

--- a/blueoil/converter/templates/include/matrix/col_major_to_row_major.h
+++ b/blueoil/converter/templates/include/matrix/col_major_to_row_major.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_COL_MAJOR_TO_ROW_MAJOR_H_INCLUDED
 #define DLK_MATRIX_COL_MAJOR_TO_ROW_MAJOR_H_INCLUDED

--- a/blueoil/converter/templates/include/matrix/multiplication.h
+++ b/blueoil/converter/templates/include/matrix/multiplication.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_MULTIPLICATION_H_INCLUDED
 #define DLK_MATRIX_MULTIPLICATION_H_INCLUDED

--- a/blueoil/converter/templates/include/matrix/quantized_multiplication.h
+++ b/blueoil/converter/templates/include/matrix/quantized_multiplication.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_QUANTIZED_MULTIPLICATION_H_INCLUDED
 #define DLK_MATRIX_QUANTIZED_MULTIPLICATION_H_INCLUDED

--- a/blueoil/converter/templates/include/matrix/row_major_to_col_major.h
+++ b/blueoil/converter/templates/include/matrix/row_major_to_col_major.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_ROW_MAJOR_TO_COL_MAJOR_H_INCLUDED
 #define DLK_MATRIX_ROW_MAJOR_TO_COL_MAJOR_H_INCLUDED

--- a/blueoil/converter/templates/include/matrix/shift_add.h
+++ b/blueoil/converter/templates/include/matrix/shift_add.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_SHIFT_ADD_H_INCLUDED
 #define DLK_MATRIX_SHIFT_ADD_H_INCLUDED

--- a/blueoil/converter/templates/include/matrix/transpose.h
+++ b/blueoil/converter/templates/include/matrix/transpose.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_MATRIX_TRANSPOSE_H_INCLUDED
 #define DLK_MATRIX_TRANSPOSE_H_INCLUDED

--- a/blueoil/converter/templates/include/memdriver.h
+++ b/blueoil/converter/templates/include/memdriver.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef MEMORY_MAPPED_WRITE_AND_CHECK
 #define MEMORY_MAPPED_WRITE_AND_CHECK

--- a/blueoil/converter/templates/include/network.tpl.h
+++ b/blueoil/converter/templates/include/network.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef NETWORK_H_INCLUDED
 #define NETWORK_H_INCLUDED

--- a/blueoil/converter/templates/include/operators.h
+++ b/blueoil/converter/templates/include/operators.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef OPERATORS_HEADER
 #define OPERATORS_HEADER

--- a/blueoil/converter/templates/include/pack_input_to_qwords.h
+++ b/blueoil/converter/templates/include/pack_input_to_qwords.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_PACK_INPUT_TO_QWORDS_H_INCLUDED
 #define DLK_PACK_INPUT_TO_QWORDS_H_INCLUDED

--- a/blueoil/converter/templates/include/quantizer.h
+++ b/blueoil/converter/templates/include/quantizer.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef QUANTIZER_H_INCLUDED
 #define QUANTIZER_H_INCLUDED

--- a/blueoil/converter/templates/include/tensor_convert.h
+++ b/blueoil/converter/templates/include/tensor_convert.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_TENSOR_CONVERT_H_INCLUDED
 #define DLK_TENSOR_CONVERT_H_INCLUDED

--- a/blueoil/converter/templates/include/tensor_save.h
+++ b/blueoil/converter/templates/include/tensor_save.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_TENSOR_SAVE_H_INCLUDED
 #define DLK_TENSOR_SAVE_H_INCLUDED

--- a/blueoil/converter/templates/include/tensor_view.h
+++ b/blueoil/converter/templates/include/tensor_view.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_TENSOR_VIEW_H_INCLUDED
 #define DLK_TENSOR_VIEW_H_INCLUDED

--- a/blueoil/converter/templates/include/time_measurement.h
+++ b/blueoil/converter/templates/include/time_measurement.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef TIME_MEASURE_HEADER
 #define TIME_MEASURE_HEADER

--- a/blueoil/converter/templates/include/types.h
+++ b/blueoil/converter/templates/include/types.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef TYPES_H
 #define TYPES_H

--- a/blueoil/converter/templates/mains/main.tpl.cpp
+++ b/blueoil/converter/templates/mains/main.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <stdio.h>
 #include <cstring>

--- a/blueoil/converter/templates/manual/consts/dlk_test_node.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/dlk_test_node.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "dlk_test/{{ test_node.name }}.h"

--- a/blueoil/converter/templates/manual/consts/dlk_test_node.tpl.h
+++ b/blueoil/converter/templates/manual/consts/dlk_test_node.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef DLK_TEST_{{ test_node.name }}_H_INCLUDED
 #define DLK_TEST_{{ test_node.name }}_H_INCLUDED

--- a/blueoil/converter/templates/manual/consts/input.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/input.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "tensor_view.h"

--- a/blueoil/converter/templates/manual/consts/input.tpl.h
+++ b/blueoil/converter/templates/manual/consts/input.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef INPUT_{{ node.name }}_H_INCLUDED
 #define INPUT_{{ node.name }}_H_INCLUDED

--- a/blueoil/converter/templates/manual/consts/scaling_factors.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/scaling_factors.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "scaling_factors.h"

--- a/blueoil/converter/templates/manual/consts/scaling_factors.tpl.h
+++ b/blueoil/converter/templates/manual/consts/scaling_factors.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef SCALING_FACTORS_H_INCLUDED
 #define SCALING_FACTORS_H_INCLUDED

--- a/blueoil/converter/templates/manual/consts/thresholds.tpl.cpp
+++ b/blueoil/converter/templates/manual/consts/thresholds.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "thresholds.h"

--- a/blueoil/converter/templates/manual/consts/thresholds.tpl.h
+++ b/blueoil/converter/templates/manual/consts/thresholds.tpl.h
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #ifndef INPUT_THRESHOLDS_H_INCLUDED
 #define INPUT_THRESHOLDS_H_INCLUDED

--- a/blueoil/converter/templates/src/func/arm_neon/batch_normalization.cpp
+++ b/blueoil/converter/templates/src/func/arm_neon/batch_normalization.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cmath>
 #include <memory>

--- a/blueoil/converter/templates/src/func/average_pool.cpp
+++ b/blueoil/converter/templates/src/func/average_pool.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <cstring>

--- a/blueoil/converter/templates/src/func/conv2d.cpp
+++ b/blueoil/converter/templates/src/func/conv2d.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <cstring>

--- a/blueoil/converter/templates/src/func/generic/batch_normalization.cpp
+++ b/blueoil/converter/templates/src/func/generic/batch_normalization.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cmath>
 #include <memory>

--- a/blueoil/converter/templates/src/func/impl/arm_neon/pop_count.cpp
+++ b/blueoil/converter/templates/src/func/impl/arm_neon/pop_count.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "func/impl/pop_count.h"
 

--- a/blueoil/converter/templates/src/func/impl/arm_neon/quantized_conv2d_tiling.cpp
+++ b/blueoil/converter/templates/src/func/impl/arm_neon/quantized_conv2d_tiling.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <climits>

--- a/blueoil/converter/templates/src/func/impl/fpga/quantized_conv2d_accelerator.cpp
+++ b/blueoil/converter/templates/src/func/impl/fpga/quantized_conv2d_accelerator.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <cstdio>

--- a/blueoil/converter/templates/src/func/impl/generic/apply_thresholds.cpp
+++ b/blueoil/converter/templates/src/func/impl/generic/apply_thresholds.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "matrix_view.h"

--- a/blueoil/converter/templates/src/func/impl/generic/pack_16bit.cpp
+++ b/blueoil/converter/templates/src/func/impl/generic/pack_16bit.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "func/impl/pack_16bit.h"
 #include <cassert>

--- a/blueoil/converter/templates/src/func/impl/generic/pop_count.cpp
+++ b/blueoil/converter/templates/src/func/impl/generic/pop_count.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "func/impl/pop_count.h"
 

--- a/blueoil/converter/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
+++ b/blueoil/converter/templates/src/func/impl/generic/quantized_conv2d_kn2row.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <cstring>

--- a/blueoil/converter/templates/src/func/impl/x86_avx/quantized_conv2d_tiling.cpp
+++ b/blueoil/converter/templates/src/func/impl/x86_avx/quantized_conv2d_tiling.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cassert>
 #include <climits>

--- a/blueoil/converter/templates/src/func/lookup.cpp
+++ b/blueoil/converter/templates/src/func/lookup.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "func/lookup.h"

--- a/blueoil/converter/templates/src/func/matmul.cpp
+++ b/blueoil/converter/templates/src/func/matmul.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "types.h"
 #include "func/matmul.h"

--- a/blueoil/converter/templates/src/func/max_pool.cpp
+++ b/blueoil/converter/templates/src/func/max_pool.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 #include <cassert>
 #include <cstring>
 #include "types.h"

--- a/blueoil/converter/templates/src/func/pad.cpp
+++ b/blueoil/converter/templates/src/func/pad.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 #include "types.h"
 #include "func/pad.h"
 #include "time_measurement.h"

--- a/blueoil/converter/templates/src/func/softmax.cpp
+++ b/blueoil/converter/templates/src/func/softmax.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cmath>
 #include <limits>

--- a/blueoil/converter/templates/src/func/x86_avx/batch_normalization.cpp
+++ b/blueoil/converter/templates/src/func/x86_avx/batch_normalization.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <cmath>
 #include <memory>

--- a/blueoil/converter/templates/src/matrix/generic/quantized_multiplication.cpp
+++ b/blueoil/converter/templates/src/matrix/generic/quantized_multiplication.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <algorithm>
 #include <cassert>

--- a/blueoil/converter/templates/src/matrix/multiplication.cpp
+++ b/blueoil/converter/templates/src/matrix/multiplication.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "matrix/multiplication.h"
 #include <memory>

--- a/blueoil/converter/templates/src/matrix/shift_add.cpp
+++ b/blueoil/converter/templates/src/matrix/shift_add.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "global.h"
 #include "matrix_view.h"

--- a/blueoil/converter/templates/src/network.tpl.cpp
+++ b/blueoil/converter/templates/src/network.tpl.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <iostream>
 #include <climits>

--- a/blueoil/converter/templates/src/network_c_interface.cpp
+++ b/blueoil/converter/templates/src/network_c_interface.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "network.h"
 

--- a/blueoil/converter/templates/src/pack_input_to_qwords.cpp
+++ b/blueoil/converter/templates/src/pack_input_to_qwords.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 #include <limits.h>
 #include "global.h"
 #include "pack_input_to_qwords.h"

--- a/blueoil/converter/templates/src/quantizer.cpp
+++ b/blueoil/converter/templates/src/quantizer.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 /***************************************
  leapmind original

--- a/blueoil/converter/templates/src/tensor_save.cpp
+++ b/blueoil/converter/templates/src/tensor_save.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include "tensor_save.h"
 

--- a/blueoil/converter/templates/src/time_measurement.cpp
+++ b/blueoil/converter/templates/src/time_measurement.cpp
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
+=============================================================================*/
 
 #include <algorithm>
 

--- a/blueoil/converter/templates/src/write_to_file.cpp
+++ b/blueoil/converter/templates/src/write_to_file.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2019 The Blueoil Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=============================================================================*/
+
 #include "types.h"
 #include <string>
 #include <fstream>

--- a/blueoil/converter/utils/__init__.py
+++ b/blueoil/converter/utils/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/data_augmentor.py
+++ b/blueoil/data_augmentor.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-# -*- coding:utf-8 -*-
 import math
 import random
 from random import randint

--- a/blueoil/datasets/__init__.py
+++ b/blueoil/datasets/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/datasets/bdd100k.py
+++ b/blueoil/datasets/bdd100k.py
@@ -1,4 +1,18 @@
 # -*- coding: utf-8 -*-
+# Copyright 2018 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import functools
 import glob
 import json

--- a/blueoil/metrics/__init__.py
+++ b/blueoil/metrics/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/networks/classification/quantize_example.py
+++ b/blueoil/networks/classification/quantize_example.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 from functools import partial
 
 import tensorflow as tf

--- a/blueoil/networks/keypoint_detection/__init__.py
+++ b/blueoil/networks/keypoint_detection/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/networks/object_detection/__init__.py
+++ b/blueoil/networks/object_detection/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/utils/__init__.py
+++ b/blueoil/utils/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/utils/box.py
+++ b/blueoil/utils/box.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import numpy as np
 
 

--- a/blueoil/utils/image.py
+++ b/blueoil/utils/image.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import numpy as np
 import PIL.Image
 

--- a/blueoil/utils/predict_output/__init__.py
+++ b/blueoil/utils/predict_output/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/blueoil/utils/predict_output/writer.py
+++ b/blueoil/utils/predict_output/writer.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import logging
 import os
 

--- a/blueoil/utils/tfds_builders/__init__.py
+++ b/blueoil/utils/tfds_builders/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import os
 from pathlib import Path
 import tempfile

--- a/tests/e2e/test_classification.py
+++ b/tests/e2e/test_classification.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import pytest
 
 from blueoil.generate_lmnet_config import generate

--- a/tests/e2e/test_keypoint_detection.py
+++ b/tests/e2e/test_keypoint_detection.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import pytest
 
 from blueoil.generate_lmnet_config import generate

--- a/tests/e2e/test_object_detection.py
+++ b/tests/e2e/test_object_detection.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import pytest
 
 from blueoil.generate_lmnet_config import generate

--- a/tests/e2e/test_semantic_segmentation.py
+++ b/tests/e2e/test_semantic_segmentation.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import pytest
 
 from blueoil.generate_lmnet_config import generate

--- a/tests/unit/util_tests/predict_output/conftest.py
+++ b/tests/unit/util_tests/predict_output/conftest.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import tempfile
 
 import pytest

--- a/tests/unit/util_tests/predict_output/test_writer.py
+++ b/tests/unit/util_tests/predict_output/test_writer.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Blueoil Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
 import json
 import os
 


### PR DESCRIPTION
## What this patch does to fix the issue.
Target files are `*.py`, `*.cpp`, `*.h`, `*.hpp`
- Add missing header license to all target file 
- Fix consistency of no. of `=` in the last line of license to 77. There are 78 for some of C++ src and header files.


## Link to any relevant issues or pull requests.
