### PR TITLE
fix for loading class names when using convert (and class names are property)

### DIFF
--- a/blueoil/utils/config.py
+++ b/blueoil/utils/config.py
@@ -64,7 +64,7 @@ REQUIEMNT_PARAMS_FOR_TRAINING = REQUIEMNT_PARAMS_FOR_INFERENCE + [
 def _saved_config_file_path():
     filepaths = [
         os.path.join(environment.EXPERIMENT_DIR, filename)
-        for filename in ('config.py', 'config.yaml')
+        for filename in ('config.yaml', 'config.py')
     ]
 
     for filepath in filepaths:


### PR DESCRIPTION
This is to fix the bug described in issue https://github.com/blue-oil/blueoil/issues/1076

The error occurs because when running convert, the [_saved_config_file_path](https://github.com/blue-oil/blueoil/blob/f57ccf6af2b5fd8210ba255a6ce46e868d9c2677/blueoil/utils/config.py#L64) function will retrieve the `config.py` file, and it will try to access `classes` property of the dataset class. However, the dataset hasn't been instantiated, so it can't access the class names.

One way around it is to create a dummy dataset, and use the `classes` property of that. But it adds a few lines of code, and creating a dummy dataset only for this purpose is not ideal.

Another way (the way in this PR), is to prefer to load `config.yaml`, rather than `config.py`. The `config.yaml` has the full class names directly listed because of [this existing code](https://github.com/blue-oil/blueoil/blob/f57ccf6af2b5fd8210ba255a6ce46e868d9c2677/blueoil/utils/config.py#L224), which is run when doing training.

The implementation is very simple, just swapping `config.py` and `config.yaml` in one line changes the order of preference for which one to use (only one is used, not both).

p.s. ["'config.yaml' is duplication of python config file as yaml."](https://github.com/blue-oil/blueoil/blob/f57ccf6af2b5fd8210ba255a6ce46e868d9c2677/blueoil/utils/config.py#L242) so it seems fine to prefer `config.yaml` over `config.py` when running the conversion.

I tested it by doing training and converting a model similar to `lm_resnet.py`, for Ilsvrc2012 dataset. By doing the change shown in this PR, it could convert.

p.s. the original issue mentions DarknetQuantize. However, after doing the fix in this PR, I still get an error when converting it `AssertionError: Pooling operator pool_1_MaxPool does not match the height: 224 vs 112.` I am pretty sure it is a different error, not related to the issue of loading class names.