### PR TITLE
remove util functions that are no longer used

### DIFF
--- a/blueoil/utils/config.py
+++ b/blueoil/utils/config.py
@@ -285,26 +285,6 @@ def copy_to_experiment_dir(config_file):
     gfile.copy(config_file, saved_config_file_path, overwrite=True)
 
 
-def init_config(config, training_id, recreate=False):
-    """Initialize config.
-
-    Set logging.
-    Train id embed to config directories.
-    """
-
-    # _init_logging(config)
-
-
-def restore_saved_image_size(config):
-    saved_config_file_path = _saved_config_file_path()
-    config = load(saved_config_file_path)
-
-    if hasattr(config, "IMAGE_SIZE"):
-        return config.IMAGE_SIZE
-
-    raise Exception("IMAGE_SIZE dont exists in file {}".format(saved_config_file_path))
-
-
 def merge(base_config, override_config):
     """merge config.
 


### PR DESCRIPTION
## What this patch does to fix the issue.
function `restore_saved_image_size` and function `init_config` are not used anymore. By doing grep -r "restore_saved_image_size" blueoil/ these keywords only appear in their definitions.
In this case, it's better to remove them. Unless developers are making use of them, or there are future plans that require them.