### PR TITLE
Add update pillow version in DE10-nano installation

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -213,12 +213,15 @@ Third, update kernel modules with:
 
 ---
 
-## Install required packages
+## Install required packages and dependencies
 
-Login to the FPGA board and update required packages.
+Login to the FPGA board and update required packages and dependencies.
 
     $ apt-get update
     $ apt-get install python-dev python-setuptools python-pip unzip
+    $ export LC_ALL=en_US.UTF-8
+    $ pip install --upgrade pip
+    $ pip install -U Pillow --no-cache-dir
 
 ---
 


### PR DESCRIPTION
## What this patch does to fix the issue.
Reported from @lm-tajimi about Outpute_template contains newer Pillow library dependency. That DE10 OS image's Pillow is not supported.

I updated the document and add  update pillow dependency in the DE10-nano installation


## Link to any relevant issues or pull requests.
-