### PR TITLE
FIx to set correct gs:// path

### DIFF
--- a/blueoil/environment.py
+++ b/blueoil/environment.py
@@ -33,13 +33,13 @@ _CHECKPOINTS_DIR = os.path.join(OUTPUT_DIR, "{experiment_id}", "checkpoints")
 
 def set_data_dir(path):
     global DATA_DIR
-    DATA_DIR = os.path.abspath(path)
+    DATA_DIR = path if is_gcs_path(path) else os.path.abspath(path)
     os.environ["DATA_DIR"] = DATA_DIR
 
 
 def set_output_dir(path):
     global OUTPUT_DIR
-    OUTPUT_DIR = os.path.abspath(path)
+    OUTPUT_DIR = path if is_gcs_path(path) else os.path.abspath(path)
     os.environ["OUTPUT_DIR"] = OUTPUT_DIR
 
     global _EXPERIMENT_DIR, _TENSORBOARD_DIR, _CHECKPOINTS_DIR
@@ -105,3 +105,13 @@ def teardown_test_environment():
     _EXPERIMENT_DIR = os.path.join(OUTPUT_DIR, "{experiment_id}")
     _TENSORBOARD_DIR = os.path.join(OUTPUT_DIR, "{experiment_id}", "tensorboard")
     _CHECKPOINTS_DIR = os.path.join(OUTPUT_DIR, "{experiment_id}", "checkpoints")
+
+
+def is_gcs_path(path):
+    """Check argument string is GCS path or not
+    Args:
+        path: Path like string
+    Returns:
+        True when string is GCS path
+    """
+    return path[0:5] == "gs://"

--- a/blueoil/environment.py
+++ b/blueoil/environment.py
@@ -110,7 +110,7 @@ def teardown_test_environment():
 def is_gcs_path(path):
     """Check argument string is GCS path or not
     Args:
-        path: Path like string
+        path: str
     Returns:
         True when string is GCS path
     """

--- a/blueoil/environment.py
+++ b/blueoil/environment.py
@@ -114,4 +114,4 @@ def is_gcs_path(path):
     Returns:
         True when string is GCS path
     """
-    return path[0:5] == "gs://"
+    return path.startswith("gs://")

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -104,8 +104,6 @@ class TestSetDataDir(EnvironmentTestBase):
     def test_set_data_dir_with_gcs_path(self):
         path = "gs://dataset"
         environment.set_data_dir(path)
-
-        abs_path = os.path.abspath(path)
         assert environment.DATA_DIR == path
         assert os.environ["DATA_DIR"] == path
 
@@ -153,7 +151,5 @@ class TestSetOutputDir(EnvironmentTestBase):
     def test_set_output_dir_with_gcs_path(self):
         path = "gs://output"
         environment.set_output_dir(path)
-
-        abs_path = os.path.abspath(path)
         assert environment.OUTPUT_DIR == path
         assert os.environ["OUTPUT_DIR"] == path

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -101,6 +101,14 @@ class TestSetDataDir(EnvironmentTestBase):
         assert environment.DATA_DIR == abs_path
         assert os.environ["DATA_DIR"] == abs_path
 
+    def test_set_data_dir_with_gcs_path(self):
+        path = "gs://dataset"
+        environment.set_data_dir(path)
+
+        abs_path = os.path.abspath(path)
+        assert environment.DATA_DIR == path
+        assert os.environ["DATA_DIR"] == path
+
 
 class TestSetOutputDir(EnvironmentTestBase):
     def test_set_output_dir(self):
@@ -141,3 +149,11 @@ class TestSetOutputDir(EnvironmentTestBase):
         assert environment.CHECKPOINTS_DIR == os.path.join(
             abs_path, experiment_id, "checkpoints",
         )
+
+    def test_set_output_dir_with_gcs_path(self):
+        path = "gs://output"
+        environment.set_output_dir(path)
+
+        abs_path = os.path.abspath(path)
+        assert environment.OUTPUT_DIR == path
+        assert os.environ["OUTPUT_DIR"] == path


### PR DESCRIPTION
## What this patch does to fix the issue.

Fix #1121

If `path` is started with `gs://`, then we do *not* add convert to local absolute path.