### PR TITLE
Fix config specification table layout

### DIFF
--- a/docs/specification/config.md
+++ b/docs/specification/config.md
@@ -14,6 +14,7 @@ Go to section:
 
 
 ## Contents
+
 |config name|type|value|usage|training|inference|export|
 |---|---|---|---|---|---|---|
 |IS_DEBUG|boolean|True, False|Set True to use debug mode. It will summary some histograms, use small dataset and step size.|○|○||


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix config specification table layout.
https://docs.blue-oil.org/specification/config.html?highlight=pretrain#contents

## Link to any relevant issues or pull requests.
Closes #1123 