### PR TITLE
Change a default bit of profiling

### DIFF
--- a/blueoil/cmd/profile_model.py
+++ b/blueoil/cmd/profile_model.py
@@ -281,7 +281,7 @@ def run(experiment_id, restore_path, config_file, bit, unquant_layers):
 @click.option(
     "-b",
     "--bit",
-    default=32,
+    default=1,
     help="quantized bit",
 )
 @click.option(


### PR DESCRIPTION
## What this patch does to fix the issue.
Blueoil profile_model.py outputs `weight_size` and `quantized_weight_size`, but default quantized bit is `32`. (same as no quantized).
I think this is meanless, it is better to change the default to 1.