### PR TITLE
Add minimum package installation and network settings to rootfs setup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ rootfs-docker:
 
 .PHONY: rootfs-armhf
 rootfs-armhf: rootfs-docker
-	docker run -v $(CWD)/make_os/build:/build -it $(IMAGE_NAME)_os /build/make_rootfs.sh armhf
+	docker run --privileged -v $(CWD)/make_os/build:/build -it $(IMAGE_NAME)_os /build/make_rootfs.sh armhf
 
 .PHONY: rootfs-arm64
 rootfs-arm64: rootfs-docker
-	docker run -v $(CWD)/make_os/build:/build -it $(IMAGE_NAME)_os /build/make_rootfs.sh arm64
+	docker run --privileged -v $(CWD)/make_os/build:/build -it $(IMAGE_NAME)_os /build/make_rootfs.sh arm64
 
 .PHONY: clean
 clean:

--- a/make_os/README.md
+++ b/make_os/README.md
@@ -7,6 +7,12 @@ This document explains scripts to generate rootfs for ARM CPU and how to use tho
 - Docker 18.09.0
 - bash
 
+## Prerequisite
+You need to install QEMU user mode emulation binaries.
+```
+apt install qemu-user-static
+```
+
 ## How to run the script
 
 The operation is defferent between 32bit and 64bit.

--- a/make_os/build/make_rootfs.sh
+++ b/make_os/build/make_rootfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 if [ $# -ne 1 ]; then
 	echo "Error: Number of argument should be 1"
@@ -41,5 +41,5 @@ chroot ${ROOTFS_DIR} /bin/bash /setting_after_chroot.sh
 
 # Here is after chroot
 rm ${ROOTFS_DIR}/setting_after_chroot.sh
-tar cvzf ${BUILD_DIR}/${OUTPUT_FNAME} -C ${BUILD_DIR} rootfs --remove-file
+tar czf ${BUILD_DIR}/${OUTPUT_FNAME} -C ${BUILD_DIR} rootfs --remove-file
 chmod a=rw ${BUILD_DIR}/${OUTPUT_FNAME}

--- a/make_os/build/setting_after_chroot.sh
+++ b/make_os/build/setting_after_chroot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 # This script should be run after chroot
 /debootstrap/debootstrap --second-stage
@@ -7,4 +7,15 @@ useradd ubuntu --create-home --shell /bin/bash
 echo 'ubuntu:ubuntu' | chpasswd
 echo "ubuntu  ALL=(ALL)  ALL" >> /etc/sudoers # This enables user to sudo
 
-# TODO: Install Network tools (ifup, ifdown, Network Manager...)
+# Install minimum packages
+apt update
+apt install -y --no-install-recommends openssh-server parted
+
+# Network settings
+cat << EOF > /etc/netplan/99-network-config.yaml
+network:
+    ethernets:
+        eth0:
+            dhcp4: true
+    version: 2
+EOF


### PR DESCRIPTION
## What this patch does to fix the issue.
* Add prerequisite and necessary options of docker to create rootfs files
* Add minimum package installation and network settings to rootfs setup scripts

## Link to any relevant issues or pull requests.
