### PR TITLE
PASCAL VOC only person class for object detection

### DIFF
--- a/blueoil/datasets/pascalvoc_2007.py
+++ b/blueoil/datasets/pascalvoc_2007.py
@@ -83,3 +83,17 @@ class Pascalvoc2007(PascalvocBase):
         print("{} {} files and annotations are ready".format(self.__class__.__name__, self.subset))
 
         return files, gt_boxes_list
+
+
+class Pascalvoc2007Person(Pascalvoc2007):
+    classes = ["person"]
+
+    def __init__(
+            self,
+            *args,
+            **kwargs
+    ):
+        super().__init__(
+            *args,
+            **kwargs,
+        )

--- a/blueoil/datasets/pascalvoc_2007_2012.py
+++ b/blueoil/datasets/pascalvoc_2007_2012.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from blueoil.utils.image import load_image
 from blueoil.datasets.base import ObjectDetectionBase
-from blueoil.datasets.pascalvoc_2007 import Pascalvoc2007
-from blueoil.datasets.pascalvoc_2012 import Pascalvoc2012
+from blueoil.datasets.pascalvoc_2007 import Pascalvoc2007, Pascalvoc2007Person
+from blueoil.datasets.pascalvoc_2012 import Pascalvoc2012, Pascalvoc2012Person
 
 
 class Pascalvoc20072012(ObjectDetectionBase):
@@ -145,3 +145,20 @@ class Pascalvoc20072012ObjectDetectionPerson(Pascalvoc20072012):
             *args,
             **kwargs,
         )
+
+    def _init_files_and_annotations(self, *args, **kwargs):
+        """Create files and annotations."""
+        if self.subset == "train":
+            subset = "train_validation"
+        elif self.subset == "validation" or self.subset == "test":
+            subset = "test"
+
+        if subset == "train_validation":
+            pascalvoc_2007 = Pascalvoc2007Person(subset=subset, skip_difficult=self.skip_difficult, *args, **kwargs)
+            pascalvoc_2012 = Pascalvoc2012Person(subset=subset, skip_difficult=self.skip_difficult, *args, **kwargs)
+            self.files = pascalvoc_2007.files + pascalvoc_2012.files
+            self.annotations = pascalvoc_2007.annotations + pascalvoc_2012.annotations
+        elif subset == "test":
+            pascalvoc_2007 = Pascalvoc2007Person(subset=subset, skip_difficult=self.skip_difficult, *args, **kwargs)
+            self.files = pascalvoc_2007.files
+            self.annotations = pascalvoc_2007.annotations

--- a/blueoil/datasets/pascalvoc_2007_2012.py
+++ b/blueoil/datasets/pascalvoc_2007_2012.py
@@ -132,7 +132,7 @@ class Pascalvoc20072012(ObjectDetectionBase):
 class Pascalvoc20072012ObjectDetectionPerson(Pascalvoc20072012):
     """"PASCAL VOC only person class for object detection.
     """
-    classes = ["person"]
+    classes = default_classes = ["person"]
     num_classes = len(classes)
 
     def __init__(

--- a/blueoil/datasets/pascalvoc_2007_2012.py
+++ b/blueoil/datasets/pascalvoc_2007_2012.py
@@ -127,3 +127,21 @@ class Pascalvoc20072012(ObjectDetectionBase):
 
     def __len__(self):
         return self.num_per_epoch
+
+
+class Pascalvoc20072012ObjectDetectionPerson(Pascalvoc20072012):
+    """"PASCAL VOC only person class for object detection.
+    """
+    classes = ["person"]
+    num_classes = len(classes)
+
+    def __init__(
+            self,
+            *args,
+            **kwargs
+    ):
+
+        super().__init__(
+            *args,
+            **kwargs,
+        )

--- a/blueoil/datasets/pascalvoc_2012.py
+++ b/blueoil/datasets/pascalvoc_2012.py
@@ -83,3 +83,17 @@ class Pascalvoc2012(PascalvocBase):
         print("{} {} files and annotations are ready".format(self.__class__.__name__, self.subset))
 
         return files, gt_boxes_list
+
+
+class Pascalvoc2012Person(Pascalvoc2012):
+    classes = ["person"]
+
+    def __init__(
+            self,
+            *args,
+            **kwargs
+    ):
+        super().__init__(
+            *args,
+            **kwargs,
+        )


### PR DESCRIPTION
## What this patch does to fix the issue.
Add only person class for object detection support for PASCAL VOC format dataset

I got the idea of modification from https://github.com/blue-oil/blueoil/blob/009cd8b3123db4e5a465a010bc5b75230d311a1e/blueoil/datasets/mscoco.py#L270.

[TO DO]
- [x] Check PASCAL VOC base, it may need modification 
- [x] Test on Centernet.
- [ ] Add test
## Link to any relevant issues or pull requests.


