### PR TITLE
Make lint/type tests available without docker build

### DIFF
--- a/.buildkite/lmnet-pipeline.yml
+++ b/.buildkite/lmnet-pipeline.yml
@@ -31,7 +31,7 @@ steps:
   - command: "make test-blueoil-pep8"
     label: "pep8"
     agents:
-    - "agent-type=normal"
+    - "agent-type=container"
     - "env=production"
     timeout_in_minutes: "30"
     env:
@@ -39,7 +39,7 @@ steps:
   - command: "make test-blueoil-mypy"
     label: "mypy"
     agents:
-    - "agent-type=normal"
+    - "agent-type=container"
     - "env=production"
     timeout_in_minutes: "5"
     env:

--- a/.buildkite/lmnet-pipeline.yml
+++ b/.buildkite/lmnet-pipeline.yml
@@ -28,7 +28,7 @@ steps:
     timeout_in_minutes: "30"
     env:
       BUILDKITE_CLEAN_CHECKOUT: 'true'
-  - command: "make test-blueoil-pep8"
+  - command: "make test-lint"
     label: "pep8"
     agents:
     - "agent-type=container"
@@ -36,7 +36,7 @@ steps:
     timeout_in_minutes: "30"
     env:
       BUILDKITE_CLEAN_CHECKOUT: 'true'
-  - command: "make test-blueoil-mypy"
+  - command: "make test-mypy"
     label: "mypy"
     agents:
     - "agent-type=container"

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,18 @@ deps:
 
 .PHONY: install
 install: deps
-	pip install -e .[cpu,tests,docs]
-	pip install pycocotools==2.0.0
+	pip3 install -U pip
+	pip3 install -e .[cpu]
+	pip3 install pycocotools==2.0.0
+
+.PHONY: install-dev
+install-dev: deps install
+	pip3 install -e .[test,docs]
 
 .PHONY: install-gpu
 install-gpu: install
-	pip install -e .[gpu]
-	pip install -e .[dist]
+	pip3 install -e .[gpu]
+	pip3 install -e .[dist]
 
 .PHONY: lint
 lint:
@@ -61,15 +66,15 @@ test-keypoint-detection: build setup-test
 test-lmnet: test-blueoil-pep8 test-unit-main
 
 .PHONY: test-blueoil-pep8
-test-blueoil-pep8: build
+test-blueoil-pep8: install-dev
 	# Check blueoil pep8
 	# FIXME: blueoil/templates have a lot of errors with flake8
-	docker run ${DOCKER_OPT} $(IMAGE_NAME):$(BUILD_VERSION) /bin/bash -c "flake8 ./blueoil ./tests --exclude=templates"
+	flake8 ./blueoil ./tests --exclude=templates
 
 .PHONY: test-blueoil-mypy
-test-blueoil-mypy: build
+test-blueoil-mypy: install-dev
 	# Check blueoil mypy
-	docker run ${DOCKER_OPT} $(IMAGE_NAME):$(BUILD_VERSION) /bin/bash -c "mypy blueoil"
+	mypy blueoil
 
 .PHONY: test-unit-main
 test-unit-main: build

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ install-gpu: install
 	pip3 install -e .[gpu]
 	pip3 install -e .[dist]
 
-.PHONY: lint
-lint:
-	flake8 ./blueoil ./tests --exclude=templates
-
 .PHONY: build
 build: deps
 	# Build docker image
@@ -62,17 +58,14 @@ test-keypoint-detection: build setup-test
 	# Run Blueoil test of keypoint-detection
 	docker run ${DOCKER_OPT} -v $(CWD)/tmp:/home/blueoil/tmp $(IMAGE_NAME):$(BUILD_VERSION) pytest -n auto tests/e2e/test_keypoint_detection.py
 
-.PHONY: test-lmnet
-test-lmnet: test-blueoil-pep8 test-unit-main
-
-.PHONY: test-blueoil-pep8
-test-blueoil-pep8: install-dev
+.PHONY: test-lint
+test-lint: install-dev
 	# Check blueoil pep8
 	# FIXME: blueoil/templates have a lot of errors with flake8
 	flake8 ./blueoil ./tests --exclude=templates
 
-.PHONY: test-blueoil-mypy
-test-blueoil-mypy: install-dev
+.PHONY: test-mypy
+test-mypy: install-dev
 	# Check blueoil mypy
 	mypy blueoil
 


### PR DESCRIPTION
## What this patch does to fix the issue.
This change makes lint/type tests executed on container.
Docker build is no longer required for these tests.

