### PR TITLE
Update converter test to PY3 and drop py2 functions

### DIFF
--- a/blueoil/common.py
+++ b/blueoil/common.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from __future__ import division
-
 import math
 import numpy as np
 from enum import Enum

--- a/blueoil/post_processor.py
+++ b/blueoil/post_processor.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from __future__ import division
-
 import numpy as np
 
 from blueoil.data_augmentor import iou

--- a/blueoil/visualize.py
+++ b/blueoil/visualize.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # =============================================================================
 """Inference results visualization (decoration) functions and helpers."""
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw

--- a/output_template/python/blueoil/data_processor.py
+++ b/output_template/python/blueoil/data_processor.py
@@ -17,7 +17,6 @@ import pprint
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-import six
 
 
 class Sequence:
@@ -65,8 +64,7 @@ class Sequence:
                 process.image_size = image_size
 
 
-@six.add_metaclass(ABCMeta)
-class Processor():
+class Processor(metaclass=ABCMeta):
 
     @abstractmethod
     def __call__(self, **kwargs):

--- a/output_template/python/config.py
+++ b/output_template/python/config.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from importlib import import_module
 
 import yaml

--- a/output_template/python/lmnet/utils/demo.py
+++ b/output_template/python/lmnet/utils/demo.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 import time
 from itertools import product as itr_prod

--- a/output_template/python/motion_jpeg_server_from_camera.py
+++ b/output_template/python/motion_jpeg_server_from_camera.py
@@ -64,10 +64,12 @@ class MotionJpegHandler(BaseHTTPRequestHandler):
         fps_only_network = 0.0
 
         camera_img = stream.read()
-        pool_result = pool.apply_async(_run_inference, (camera_img, ))
+        pool_result = pool.apply_async(_run_inference, (camera_img,))
 
         self.send_response(200)
-        self.send_header('Content-type', 'multipart/x-mixed-replace; boundary=jpgboundary')
+        self.send_header(
+            "Content-type", "multipart/x-mixed-replace; boundary=jpgboundary"
+        )
         self.end_headers()
 
         visualizer = _visualizer(config.TASK)
@@ -81,14 +83,14 @@ class MotionJpegHandler(BaseHTTPRequestHandler):
                     result, fps, fps_only_network = pool_result.get()
 
                     camera_img = stream.read()
-                    pool_result = pool.apply_async(_run_inference, (camera_img, ))
+                    pool_result = pool.apply_async(_run_inference, (camera_img,))
 
                     image = visualizer(window_img, result[0], config)
                     draw_fps(image, fps, fps_only_network)
                     tmp = BytesIO()
                     image.save(tmp, "JPEG")
 
-                self.send_header('Content-type', 'image/jpeg')
+                self.send_header("Content-type", "image/jpeg")
                 self.end_headers()
                 self.wfile.write(tmp.getvalue())
 
@@ -134,22 +136,26 @@ def run(model, config_file, port=80):
     global nn, pre_process, post_process, config, stream, pool
 
     filename, file_extension = os.path.splitext(model)
-    supported_files = ['.so', '.pb']
+    supported_files = [".so", ".pb"]
 
     if file_extension not in supported_files:
-        raise Exception("""
+        raise Exception(
+            """
             Unknown file type. Got %s%s.
             Please check the model file (-m).
             Only .pb (protocol buffer) or .so (shared object) file is supported.
-            """ % (filename, file_extension))
+            """
+            % (filename, file_extension)
+        )
 
-    if file_extension == '.so':  # Shared library
+    if file_extension == ".so":  # Shared library
         nn = NNLib()
         nn.load(model)
 
-    elif file_extension == '.pb':  # Protocol Buffer file
+    elif file_extension == ".pb":  # Protocol Buffer file
         # only load tensorflow if user wants to use GPU
         from lmnet.tensorflow_graph_runner import TensorflowGraphRunner
+
         nn = TensorflowGraphRunner(model)
 
     nn = NNLib()
@@ -165,7 +171,7 @@ def run(model, config_file, port=80):
     pool = Pool(processes=1, initializer=_init_worker)
 
     try:
-        server = ThreadedHTTPServer(('', port), MotionJpegHandler)
+        server = ThreadedHTTPServer(("", port), MotionJpegHandler)
         print("server starting")
         server.serve_forever()
     except KeyboardInterrupt:
@@ -179,13 +185,13 @@ def run(model, config_file, port=80):
     return
 
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
     "-m",
     "-l",
     "--model",
     type=click.Path(exists=True),
-    help=u"""
+    help="""
         Inference Model filename
         (-l is deprecated please use -m instead)
     """,
@@ -195,15 +201,10 @@ def run(model, config_file, port=80):
     "-c",
     "--config_file",
     type=click.Path(exists=True),
-    help=u"Config file Path",
+    help="Config file Path",
     default="../models/meta.yaml",
 )
-@click.option(
-    "-p",
-    "--port",
-    default=80,
-    help="Port number of motion jpege server."
-)
+@click.option("-p", "--port", default=80, help="Port number of motion jpege server.")
 def main(model, config_file, port):
     """Serve motion jpeg server from video camera source.
 
@@ -217,7 +218,7 @@ def main(model, config_file, port):
 
 def _check_deprecated_arguments():
     argument_list = sys.argv
-    if '-l' in argument_list:
+    if "-l" in argument_list:
         print("Deprecated warning: -l is deprecated please use -m instead")
 
 

--- a/output_template/python/requirements.txt
+++ b/output_template/python/requirements.txt
@@ -3,4 +3,3 @@ easydict==1.9
 numpy==1.19.1
 Pillow==7.2.
 PyYAML==5.3.1
-six==1.15.0

--- a/output_template/python/usb_camera_demo.py
+++ b/output_template/python/usb_camera_demo.py
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import time
 import os
 import sys

--- a/tests/converter/test_code_generation.py
+++ b/tests/converter/test_code_generation.py
@@ -299,7 +299,7 @@ class TestCodeGenerationBase(TestCaseDLKBase):
 
         remote_output_file = join(output_path, "remote.out")
         run_and_check(
-            ["ssh", f"root@{host}", f"cd ~/automated_testing/; python {testing_code_name}"],
+            ["ssh", f"root@{host}", f"cd ~/automated_testing/; python3 {testing_code_name}"],
             output_path,
             remote_output_file,
             join(output_path, "remote.err"),


### PR DESCRIPTION
## What this patch does to fix the issue.
 - Update `test_code_generation` to use python3 expressly 
 - Drop PY2 functionalities from output_template
 
## Link to any relevant issues or pull requests.