### PR TITLE
Add unittest CI environment for inference scripts (output_template)

### DIFF
--- a/.buildkite/lmnet-pipeline.yml
+++ b/.buildkite/lmnet-pipeline.yml
@@ -28,6 +28,14 @@ steps:
     timeout_in_minutes: "30"
     env:
       BUILDKITE_CLEAN_CHECKOUT: 'true'
+  - command: "make test-unit-inference"
+    label: "inference"
+    agents:
+    - "agent-type=normal"
+    - "env=production"
+    timeout_in_minutes: "30"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: 'true'
   - command: "make test-lint"
     label: "pep8"
     agents:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test-unit-main: build
 .PHONY: test-unit-inference
 test-unit-inference: build-inference
 	# Run inference test with Python3.6
-	docker run ${DOCKER_OPT} $(INFERENCE_IMAGE_NAME):$(BUILD_VERSION) pytest -n auto tests/output_template/
+	docker run ${DOCKER_OPT} $(INFERENCE_IMAGE_NAME):$(BUILD_VERSION) python3 -m unittest discover tests/output_template/
 
 .PHONY: test-dlk
 test-dlk: test-dlk-main test-dlk-x86_64 test-dlk-x86_64_avx test-dlk-arm test-dlk-arm_fpga test-dlk-aarch64 test-dlk-aarch64_fpga

--- a/docker/Dockerfile-inference
+++ b/docker/Dockerfile-inference
@@ -1,0 +1,44 @@
+FROM ubuntu:18.04 AS base
+
+LABEL maintainer="admin@blueoil.org"
+
+RUN apt-get update && apt-get install -y \
+    locales\
+    python3 \
+    python3-pip \
+    libjpeg8-dev \
+    zlib1g-dev \
+    libfreetype6-dev \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Locale setting
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+WORKDIR /home/blueoil
+RUN pip3 install -U pip setuptools
+
+FROM base AS blueoil-inference
+
+# Copy files for inference
+COPY blueoil /home/blueoil/blueoil
+COPY output_template /home/blueoil/output_template
+
+# Install packages
+RUN pip install -r /home/blueoil/output_template/python/requirements.txt
+
+WORKDIR /home/blueoil/output_template/python
+ENV PYTHONPATH=/home/blueoil/output_template/python
+RUN chmod 777 /home/blueoil/output_template/python/
+
+FROM blueoil-inference AS blueoil-inference-dev
+
+# Install packages for development
+RUN pip install -r /home/blueoil/output_template/python/dev-requirements.txt
+
+# Copy files for test
+COPY tests tests

--- a/docker/Dockerfile-inference
+++ b/docker/Dockerfile-inference
@@ -37,8 +37,5 @@ RUN chmod 777 /home/blueoil/output_template/python/
 
 FROM blueoil-inference AS blueoil-inference-dev
 
-# Install packages for development
-RUN pip install -r /home/blueoil/output_template/python/dev-requirements.txt
-
 # Copy files for test
 COPY tests tests

--- a/output_template/python/dev-requirements.txt
+++ b/output_template/python/dev-requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==5.3.5
+pytest-xdist==1.31.0

--- a/output_template/python/dev-requirements.txt
+++ b/output_template/python/dev-requirements.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-pytest==5.3.5
-pytest-xdist==1.31.0

--- a/tests/output_template/test_run.py
+++ b/tests/output_template/test_run.py
@@ -1,0 +1,13 @@
+import time
+from unittest import TestCase
+
+from run import _timerfunc
+
+
+class TestRun(TestCase):
+
+    def test_timerfunc(self):
+        def sleep(sec):
+            time.sleep(sec)
+        _, got = _timerfunc(sleep, [1])
+        self.assertEqual(int(got), 1)


### PR DESCRIPTION
## What this patch does to fix the issue.
A part of #1152 

* add Dockerfile for inference
* add test-unit-inference to Makefile
* add test-unit-inference to buildkite pipeline
* add a small test for run.py to check test environment works well (I am planning to add more tests after this PR)

## Link to any relevant issues or pull requests.
