### PR TITLE
Fix argument order for Resize function

### DIFF
--- a/runtime/include/blueoil_image.hpp
+++ b/runtime/include/blueoil_image.hpp
@@ -29,7 +29,7 @@ enum ResizeFilter {
 
 Tensor LoadImage(const std::string filename);
 
-Tensor Resize(const Tensor& image, const int width, const int height,
+Tensor Resize(const Tensor& image, const int height, const int width,
               const enum ResizeFilter filter);
 
 }  // namespace image

--- a/runtime/src/blueoil_image.cpp
+++ b/runtime/src/blueoil_image.cpp
@@ -218,7 +218,7 @@ Tensor ResizeVertical_BiLinear(const Tensor &tensor, const int height) {
   return dstTensor;
 }
 
-Tensor Resize(const Tensor& image, const int width, const int height,
+Tensor Resize(const Tensor& image, const int height, const int width,
               const enum ResizeFilter filter) {
   auto shape = image.shape();
   int channels = shape[2];


### PR DESCRIPTION
## What this patch does to fix the issue.
This PR fix not an appropriate order for width and height argument for a Resize function

## Link to any relevant issues or pull requests.
Fix #1158 