### PR TITLE
Fix absl-py version to 0.8.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,10 @@ install_requires =
 
 [options.extras_require]
 cpu =
+  absl-py==0.8.1
   tensorflow==1.15.3
 gpu =
+  absl-py==0.8.1
   tensorflow-gpu==1.15.3
 dist =
   horovod==0.19.5


### PR DESCRIPTION
## What this patch does to fix the issue.
This PR fix absl-py version to 0.8.1 (the latest version before 0.9)
Because absl-py require <0.9, >=0.7

Note that Blueoil code didn't require ` absl-py` but it required by TensorFlow.

## Link to any relevant issues or pull requests.
#1167 