### PR TITLE
Fix shapes and available_subset of FER2013 loader

### DIFF
--- a/blueoil/datasets/fer_2013.py
+++ b/blueoil/datasets/fer_2013.py
@@ -95,7 +95,8 @@ class FER2013(Base):
         labels = np.empty(data_num, dtype=np.uint8)
         for i in range(data_num):
             tmp_img = np.array(data[i][1].split(' '), np.uint8).reshape((image_size, image_size))
-            # network.Base class requires that image data have 3-channels
+            # expand a 1-channel image into 3-channels one
+            # because network.Base class requires that image data have 3-channels
             images[i] = np.stack((tmp_img, ) * 3, axis=-1)
             labels[i] = data[i][0]
         # convert to one hot encoding

--- a/blueoil/datasets/fer_2013.py
+++ b/blueoil/datasets/fer_2013.py
@@ -56,7 +56,7 @@ class FER2013(Base):
     ]
     image_size = 48
     num_classes = len(classes)
-    available_subsets = ["train", "test"]
+    available_subsets = ["train", "validation", "test"]
     extend_dir = "FER2013"
 
     def __init__(self, subset="train", batch_size=100, *args, **kwargs):
@@ -74,46 +74,43 @@ class FER2013(Base):
 
         return len(self.images)
 
-    def _load_data(self, path):
+    def _load_data(self, path, data_type):
         # Load the label and image data from csv
         lines = _load_csv(path)
-        train = []
-        public_test = []
-        for line in lines:
-            if line[2] == "Training":
-                train.append(line)
-            elif line[2] == "PublicTest":
-                public_test.append(line)
 
-        train_num = len(train)
-        public_test_num = len(public_test)
+        target = ""
+        if data_type == "train":
+            target = "Training"
+        elif data_type == "validation":
+            target = "PublicTest"
+        elif data_type == "test":
+            target = "PrivateTest"
+        else:
+            raise ValueError("Must provide data_type = train or validation or test")
+
+        data = [line for line in lines if line[2] == target]
+        data_num = len(data)
         image_size = self.image_size
 
-        train_images = np.empty((train_num, image_size, image_size), dtype=np.uint8)
-        train_labels = np.empty(train_num, dtype=np.uint8)
-        public_test_images = np.empty((public_test_num, image_size, image_size), dtype=np.uint8)
-        public_test_labels = np.empty(public_test_num, dtype=np.uint8)
+        images = np.empty((data_num, image_size, image_size, 3), dtype=np.uint8)
+        labels = np.empty(data_num, dtype=np.uint8)
+        for i in range(data_num):
+            tmp_img = np.array(data[i][1].split(' '), np.uint8).reshape((image_size, image_size))
+            # convert grayscale to RGB
+            images[i] = np.stack((tmp_img, ) * 3, axis=-1)
+            labels[i] = data[i][0]
+        # convert to one hot
+        labels = np.eye(self.num_classes)[labels]
 
-        for i in range(train_num):
-            train_images[i] = np.array(train[i][1].split(' '), np.uint8).reshape((image_size, image_size))
-            train_labels[i] = train[i][0]
-        for i in range(public_test_num):
-            public_test_images[i] = np.array(public_test[i][1].split(' '), np.uint8).reshape((image_size, image_size))
-            public_test_labels[i] = public_test[i][0]
-
-        return (train_images, train_labels), (public_test_images, public_test_labels)
+        return (images, labels)
 
     def _images_and_labels(self):
-        images = np.empty([0, self.image_size, self.image_size])
-        labels = np.empty([0])
+        images = np.empty([0, self.image_size, self.image_size, 3])
+        labels = np.empty([0, self.num_classes])
         for path in self._all_files():
-            (train_imgs, train_lbls), (test_imgs, test_lbls) = self._load_data(path)
-            if self.subset == "train":
-                images = np.concatenate([images, train_imgs])
-                labels = np.concatenate([labels, train_lbls])
-            else:
-                images = np.concatenate([images, test_imgs])
-                labels = np.concatenate([labels, test_lbls])
+            (curr_imgs, curr_lbls) = self._load_data(path, self.subset)
+            images = np.concatenate([images, curr_imgs])
+            labels = np.concatenate([labels, curr_lbls])
 
         if self.subset == "train":
             images, labels = shuffle(images, labels, seed=0)

--- a/blueoil/datasets/fer_2013.py
+++ b/blueoil/datasets/fer_2013.py
@@ -74,19 +74,18 @@ class FER2013(Base):
 
         return len(self.images)
 
-    def _load_data(self, path, data_type):
+    def _load_data(self, path, subset):
         # Load the label and image data from csv
         lines = _load_csv(path)
 
-        target = ""
-        if data_type == "train":
+        if subset == "train":
             target = "Training"
-        elif data_type == "validation":
+        elif subset == "validation":
             target = "PublicTest"
-        elif data_type == "test":
+        elif subset == "test":
             target = "PrivateTest"
         else:
-            raise ValueError("Must provide data_type = train or validation or test")
+            raise ValueError("Must provide subset = train or validation or test")
 
         data = [line for line in lines if line[2] == target]
         data_num = len(data)
@@ -96,10 +95,10 @@ class FER2013(Base):
         labels = np.empty(data_num, dtype=np.uint8)
         for i in range(data_num):
             tmp_img = np.array(data[i][1].split(' '), np.uint8).reshape((image_size, image_size))
-            # convert grayscale to RGB
+            # network.Base class requires that image data have 3-channels
             images[i] = np.stack((tmp_img, ) * 3, axis=-1)
             labels[i] = data[i][0]
-        # convert to one hot
+        # convert to one hot encoding
         labels = np.eye(self.num_classes)[labels]
 
         return (images, labels)
@@ -108,9 +107,9 @@ class FER2013(Base):
         images = np.empty([0, self.image_size, self.image_size, 3])
         labels = np.empty([0, self.num_classes])
         for path in self._all_files():
-            (curr_imgs, curr_lbls) = self._load_data(path, self.subset)
-            images = np.concatenate([images, curr_imgs])
-            labels = np.concatenate([labels, curr_lbls])
+            (tmp_images, tmp_labels) = self._load_data(path, self.subset)
+            images = np.concatenate([images, tmp_images])
+            labels = np.concatenate([labels, tmp_labels])
 
         if self.subset == "train":
             images, labels = shuffle(images, labels, seed=0)

--- a/tests/unit/datasets_tests/test_fer_2013.py
+++ b/tests/unit/datasets_tests/test_fer_2013.py
@@ -28,4 +28,4 @@ def test_fer2013():
     assert dataset[0][0].shape[0] == dataset.image_size
     assert dataset[0][0].shape[1] == dataset.image_size
     assert dataset[0][0].shape[2] == 3
-    assert (dataset[0][1] == np.eye(dataset.num_classes)[0]).all()
+    assert (dataset[0][1] == np.array([1, 0, 0, 0, 0, 0, 0])).all()

--- a/tests/unit/datasets_tests/test_fer_2013.py
+++ b/tests/unit/datasets_tests/test_fer_2013.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # =============================================================================
 import pytest
+import numpy as np
 
 from blueoil.datasets.fer_2013 import FER2013
 
@@ -22,8 +23,9 @@ pytestmark = pytest.mark.usefixtures("set_test_environment")
 def test_fer2013():
     dataset = FER2013()
     assert len(dataset.classes) == 7
-    assert dataset.available_subsets == ['train', 'test']
+    assert dataset.available_subsets == ['train', 'validation', 'test']
     assert len(dataset) == 1
     assert dataset[0][0].shape[0] == dataset.image_size
     assert dataset[0][0].shape[1] == dataset.image_size
-    assert dataset[0][1] == 0
+    assert dataset[0][0].shape[2] == 3
+    assert (dataset[0][1] == np.eye(dataset.num_classes)[0]).all()


### PR DESCRIPTION
## What this patch does to fix the issue.
- Fix shapes of the FER2013 dataset loader
  - Convert to `NWHC` format
  - Expand a 1-channel image to 3-channels one
- Add "validation" to `available_subsets` of the FER2013 dataset loader

## Link to any relevant issues or pull requests.
Closes https://github.com/blue-oil/blueoil/issues/1176 https://github.com/blue-oil/blueoil/issues/1173