### PR TITLE
Use g++-8 to keep consistency in each architecture

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,10 +9,6 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:${LD_LIBRARY_PATH} \
     CUDA_HOME=/usr/local/cuda-10.0 \
     DEBIAN_FRONTEND=noninteractive
 
-# Add source list entry for GCC 9
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 60C317803A41BA51845E371A1E9377A2BA9EF27F
-RUN echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main' | tee /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test.list
-
 RUN apt-get update && apt-get install -y \
     cmake \
     fonts-dejavu \
@@ -30,8 +26,8 @@ RUN apt-get update && apt-get install -y \
     make \
     build-essential \
     wget \
-    g++-9 \
-    crossbuild-essential-arm64 \
+    g++-8 \
+    g++-8-aarch64-linux-gnu \
     g++-8-arm-linux-gnueabihf \
     openssh-client \
     openssh-server \
@@ -39,7 +35,9 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 RUN ln -s /usr/bin/arm-linux-gnueabihf-g++-8 /usr/bin/arm-linux-gnueabihf-g++
+RUN ln -s /usr/bin/aarch64-linux-gnu-g++-8 /usr/bin/aarch64-linux-gnu-g++
 
 # Install OpenSSH for MPI to communicate between containers
 RUN mkdir -p /var/run/sshd


### PR DESCRIPTION
## What this patch does to fix the issue.
Close #1189 

```
% docker run --rm -it blueoil_masuda:v0.27.0-18-g4db3ba40 /bin/bash
root@2cc8feb8e3a2:/home/blueoil# g++ --version
g++ (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

root@2cc8feb8e3a2:/home/blueoil# arm-linux-gnueabihf-g++ --version
arm-linux-gnueabihf-g++ (Ubuntu/Linaro 8.4.0-1ubuntu1~18.04) 8.4.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

root@2cc8feb8e3a2:/home/blueoil# aarch64-linux-gnu-g++ --version
aarch64-linux-gnu-g++ (Ubuntu/Linaro 8.4.0-1ubuntu1~18.04) 8.4.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Link to any relevant issues or pull requests.
