### PR TITLE
change python to python3 in usage docs

### DIFF
--- a/docs/usage/convert.md
+++ b/docs/usage/convert.md
@@ -1,7 +1,7 @@
 # Convert your training result to FPGA ready format
 
 ```
-$ python blueoil/cmd/main.py convert -e test_20180101000000
+$ python3 blueoil/cmd/main.py convert -e test_20180101000000
 
 Usage:
   main.py convert [OPTIONS]
@@ -15,6 +15,6 @@ Usage:
     --help                          Show this message and exit.
 ```
 
-`python blueoil/cmd/main.py convert` command converts trained models to executable binary files for x86, ARM Cortex-A9, and FPGA.
+`python3 blueoil/cmd/main.py convert` command converts trained models to executable binary files for x86, ARM Cortex-A9, and FPGA.
 
 

--- a/docs/usage/evaluate.md
+++ b/docs/usage/evaluate.md
@@ -3,7 +3,7 @@ Main evaluation script is `blueoil/cmd/evaluate.py`.
 When you start doing evaluation, you need to specify some (required) options.
 You can see the option descriptions with `-h` flag.
 ```
-# python blueoil/cmd/evaluate.py -h
+# python3 blueoil/cmd/evaluate.py -h
 Usage: evaluate.py [OPTIONS]
 
 Options:

--- a/docs/usage/export.md
+++ b/docs/usage/export.md
@@ -12,7 +12,7 @@ In the case with `images` option, create each layer output value npy files in `e
 * Write summary in tensorboard `export` dir.
 
 ```
-# python blueoil/cmd/export.py -h
+# python3 blueoil/cmd/export.py -h
 Usage: export.py [OPTIONS]
 
   Exporting a trained model to proto buffer files and meta config yaml.
@@ -35,4 +35,4 @@ Options:
 ```
 
 e.g.
-`python blueoil/cmd/export.py -i lmnet_cifar10 --restore_path saved/lmnet_cifar10/checkpoints/save.ckpt-99001 --images apple_128.png --images apple.png --image_size 128 192`
+`python3 blueoil/cmd/export.py -i lmnet_cifar10 --restore_path saved/lmnet_cifar10/checkpoints/save.ckpt-99001 --images apple_128.png --images apple.png --image_size 128 192`

--- a/docs/usage/init.md
+++ b/docs/usage/init.md
@@ -1,10 +1,10 @@
 # Generate a configuration file
 
-You can generate your configuration file interactively by running `python blueoil/cmd/main.py init`.
+You can generate your configuration file interactively by running `python3 blueoil/cmd/main.py init`.
 
-    $ python blueoil/cmd/main.py init
+    $ python3 blueoil/cmd/main.py init
 
-`python blueoil/cmd/main.py init` generates a configuration file used to train your new model.
+`python3 blueoil/cmd/main.py init` generates a configuration file used to train your new model.
 
 Below is an example.
 ```

--- a/docs/usage/measure_latency.md
+++ b/docs/usage/measure_latency.md
@@ -31,7 +31,7 @@ Options:
 
 e.g.
 ```
-$ python blueoil/cmd/measure_latency.py -c configs/core/object_detection/lm_fyolo_quantize_pascalvoc_2007_2012.py -n 20 --image_size 160 160
+$ python3 blueoil/cmd/measure_latency.py -c configs/core/object_detection/lm_fyolo_quantize_pascalvoc_2007_2012.py -n 20 --image_size 160 160
 
 ...
 ---- measure latency result ----

--- a/docs/usage/predict.md
+++ b/docs/usage/predict.md
@@ -9,7 +9,7 @@ Save the predictions npy, json, images results to output dir.
 The output predictions Tensor(npy) and json format depends on task type. Plsease see [Output Data Specification](../specification/output_data.md).
 
 ```
-# python blueoil/cmd/main.py predict --help
+# python3 blueoil/cmd/main.py predict --help
 Usage: main.py predict [OPTIONS]
 
   Predict by using trained model.

--- a/docs/usage/profile_model.md
+++ b/docs/usage/profile_model.md
@@ -4,7 +4,7 @@ Profiling a trained model.
 If it exists unquantized layers, use `-uql` to point it out.
 
 ```
-# python blueoil/cmd/profile_model.py -h
+# python3 blueoil/cmd/profile_model.py -h
 Usage: profile_model.py [OPTIONS]
 
   Profiling a trained model.
@@ -27,6 +27,6 @@ Options:
 ```
 
 e.g.
-`python blueoil/cmd/profile_model.py -i lmnet_cifar10 --restore_path saved/lmnet_cifar10/checkpoints/save.ckpt-99001 --bit 2 -uql conv1 -uql conv7`
+`python3 blueoil/cmd/profile_model.py -i lmnet_cifar10 --restore_path saved/lmnet_cifar10/checkpoints/save.ckpt-99001 --bit 2 -uql conv1 -uql conv7`
 
-`python blueoil/cmd/executor/profile_model.py -c configs/core/classification/lmnet_cifar10.py --bit 1`
+`python3 blueoil/cmd/executor/profile_model.py -c configs/core/classification/lmnet_cifar10.py --bit 1`

--- a/docs/usage/train.md
+++ b/docs/usage/train.md
@@ -2,7 +2,7 @@
 
 
 ```
-$ python blueoil/cmd/main.py train -c config/test.py
+$ python3 blueoil/cmd/main.py train -c config/test.py
 
 Usage:
   main.py train [OPTIONS]
@@ -14,9 +14,9 @@ Arguments:
   --help                    Show this message and exit.
 ```
 
-`python blueoil/cmd/main.py train` command runs actual training.
+`python3 blueoil/cmd/main.py train` command runs actual training.
 
-Before running `python blueoil/cmd/main.py train`, make sure you've already put training/test data in the proper location, as defined in the configuration file.
+Before running `python3 blueoil/cmd/main.py train`, make sure you've already put training/test data in the proper location, as defined in the configuration file.
 
 If you want to stop training, you should press `Ctrl + C` or kill the `blueoil train` processes. You can restart training from saved checkpoints by setting `experiment_id` to be the same as an existing id.
 


### PR DESCRIPTION
This PR is for the following issue https://github.com/blue-oil/blueoil/issues/1188. The point is simply to change the documentation of Blueoil command from `python` (which causes error in the docker container), to `python3`.

There is also documentation that mentions `python` in [converter/overview.md](https://github.com/blue-oil/blueoil/blob/master/docs/converter/overview.md), [converter/shared_library.md](https://github.com/blue-oil/blueoil/blob/master/docs/converter/shared_library.md), and several files in docs/tutorial. But in each of those cases, it looks like it is being explained from the perspective of outside a container, where someone would likely be using a python environment etc. So I didn't change the documentation in those cases.

### testing it out

I'm not sure it was really necessary, but I ran (using python3, rather than simply python) each of : init, train, convert, predict, export, evaluate, measure_latency, profile_model (for cifar classification), in the style of
```
docker run --runtime=nvidia -e CUDA_VISIBLE_DEVICES="0" -e PYTHONPATH=.:lmnet:dlk/python/dlk --rm -it -v `pwd`:/home/blueoil -w /home/blueoil -v <path to dataset dir>:/home/blueoil/dataset:ro --user=$(id -u):$(id -g) <docker image> python3 blueoil/cmd/main.py <specific command>
```
(or in some cases, like blueoil/cmd/\<specific command\>.py). They all seemed to run fine.