### PR TITLE
change the option name in export documentation to "image"

### DIFF
--- a/docs/usage/export.md
+++ b/docs/usage/export.md
@@ -28,7 +28,7 @@ Options:
                                   input image size height and width. if it is
                                   not provided, it restore from saved
                                   experiment config. e.g. --image_size 320 320
-  --images TEXT                   path of target images
+  --image TEXT                    path of target images
   -c, --config_file TEXT          config file path. override saved experiment
                                   config.
   -h, --help                      Show this message and exit.


### PR DESCRIPTION
In the docs, this option is called "images", but when running the export code, an error will come up
```
Usage: export.py [OPTIONS]
Try 'export.py -h' for help.

Error: no such option: --images
```
It's because the actual option is "image". (which you can see by running 'export.py -h').
When using "image", it works fine. So this PR is just for correcting the documentation.