### PR TITLE
Fix confitions not to use tfds_pre_processor and tfds_augumentor

### DIFF
--- a/blueoil/datasets/dataset_iterator.py
+++ b/blueoil/datasets/dataset_iterator.py
@@ -242,7 +242,7 @@ class _TFDSReader:
 
     def __init__(self, dataset, local_rank):
         tf_dataset = dataset.tf_dataset.shuffle(1024).repeat()
-        if hasattr(dataset, 'tfds_pre_processor') or hasattr(dataset, 'tfds_augmentor'):
+        if dataset.tfds_pre_processor or dataset.tfds_augmentor:
             tf_dataset = tf_dataset.map(map_func=_generate_tfds_map_func(dataset),
                                         num_parallel_calls=tf.data.experimental.AUTOTUNE)
 
@@ -267,7 +267,7 @@ class _TFDSReader:
 
     def read(self):
         """Return batch size data."""
-        if hasattr(self.dataset, 'tfds_pre_processor') or hasattr(self.dataset, 'tfds_augmentor'):
+        if self.dataset.tfds_pre_processor or self.dataset.tfds_augmentor:
             return self.session.run(self.next_batch)
 
         # if normal pre_processor is defined, use this


### PR DESCRIPTION
## What this patch does to fix the issue.
`TFDSMixin` always has attr of `tfds_pre_processor` and `tfds_augumentor`, so the conditions are always true and we cannot use normal pre-process and augmentation when we train with TFDS. I fixed these conditions to be able to run train with normal pre-process and augmentation.
https://github.com/blue-oil/blueoil/blob/ba646b908e7036f7ef5249d1523e35123873697f/blueoil/datasets/tfds.py#L117-L118


## Link to any relevant issues or pull requests.
