### PR TITLE
Avoid ValueError for TFDS with BBox on the last pixel

### DIFF
--- a/blueoil/utils/tfds_builders/object_detection.py
+++ b/blueoil/utils/tfds_builders/object_detection.py
@@ -77,8 +77,8 @@ class ObjectDetectionBuilder(tfds.core.GeneratorBasedBuilder):
                     "bbox": tfds.features.BBox(
                         ymin / height,
                         xmin / width,
-                        (ymin + h) / height,
-                        (xmin + w) / width,
+                        min((ymin + h) / height, 1.0),
+                        min((xmin + w) / width, 1.0),
                     )
                 }
                 for xmin, ymin, w, h, label in annotations


### PR DESCRIPTION
## What this patch does to fix the issue.
Fix #1208 

## Link to any relevant issues or pull requests.
