### PR TITLE
Remove config yaml

### DIFF
--- a/blueoil/cmd/export.py
+++ b/blueoil/cmd/export.py
@@ -143,16 +143,16 @@ def _export(config, restore_path, image_path):
         _save_all_operation_outputs(
             image_path, inference_values_output_dir, image, raw_image, all_outputs, config.IMAGE_SIZE)
 
-    yaml_names = config_util.save_yaml(main_output_dir, config)
+    yaml_name = config_util.save_yaml(main_output_dir, config)
     pb_name = executor.save_pb_file(sess, main_output_dir)
 
     message = """
-Create pb and yaml files in: {}
+Create pb and yaml file in: {}
 pb: {}
-yaml: {}, {}
+yaml: {}
 """.format(main_output_dir,
            pb_name,
-           *yaml_names)
+           yaml_name)
 
     if image_path:
         message += "Create npy files in under `inference_test_data` folder \n"
@@ -232,7 +232,7 @@ def run(experiment_id,
     help="config file path. override saved experiment config.",
 )
 def main(experiment_id, restore_path, image_size, image, config_file):
-    """Exporting a trained model to proto buffer files and meta config yaml.
+    """Exporting a trained model to proto buffer files and meta yaml.
 
     In the case with `image` option, create each layer output value npy files into
     `export/{restore_path}/{image_size}/inference_test_data/**.npy` as expected value for inference test and debug.

--- a/blueoil/utils/config.py
+++ b/blueoil/utils/config.py
@@ -19,7 +19,6 @@ from abc import ABCMeta
 
 import yaml
 from blueoil.utils.smartdict import SmartDict
-from yaml.representer import Representer
 
 from blueoil.data_processor import Processor, Sequence
 from blueoil import environment
@@ -62,16 +61,11 @@ REQUIEMNT_PARAMS_FOR_TRAINING = REQUIEMNT_PARAMS_FOR_INFERENCE + [
 
 
 def _saved_config_file_path():
-    filepaths = [
-        os.path.join(environment.EXPERIMENT_DIR, filename)
-        for filename in ('config.py', 'config.yaml')
-    ]
+    filepath = os.path.join(environment.EXPERIMENT_DIR, 'config.py')
+    if file_io.exists(filepath):
+        return filepath
 
-    for filepath in filepaths:
-        if file_io.exists(filepath):
-            return filepath
-
-    raise FileNotFoundError("Config file not found: '{}'".format("' nor '".join(filepaths)))
+    raise FileNotFoundError("Config file not found: '{}'".format(filepath))
 
 
 def _config_file_path_to_copy(config_file):
@@ -79,11 +73,9 @@ def _config_file_path_to_copy(config_file):
 
     if file_extension.lower() in '.py':
         filename = 'config.py'
-    elif file_extension.lower() in ('.yml', '.yaml'):
-        filename = 'config.yaml'
     else:
         raise ValueError('Config file type is not supported.'
-                         'Should be .py, .yaml or .yml. Received {}.'.format(file_extension))
+                         'Should be .py. Received {}.'.format(file_extension))
 
     return os.path.join(environment.EXPERIMENT_DIR, filename)
 
@@ -114,11 +106,9 @@ def load(config_file):
     filename, file_extension = os.path.splitext(config_file)
     if file_extension.lower() in '.py':
         loader = _load_py
-    elif file_extension.lower() in ('.yml', '.yaml'):
-        loader = _load_yaml
     else:
         raise ValueError('Config file type is not supported.'
-                         'Should be .py, .yaml or .yml. Received {}.'.format(file_extension))
+                         'Should be .py. Received {}.'.format(file_extension))
     config = loader(config_file)
 
     check_config(config)
@@ -211,56 +201,14 @@ def _save_meta_yaml(output_dir, config):
     return file_path
 
 
-def _save_config_yaml(output_dir, config):
-    file_name = 'config.yaml'
-    config_dict = _smart_dict_to_dict(config)
-    file_path = os.path.join(output_dir, file_name)
-
-    class Dumper(yaml.Dumper):
-        def ignore_aliases(self, data):
-            return True
-    Dumper.add_representer(ABCMeta, Representer.represent_name)
-
-    if type(config_dict['CLASSES']) != list:
-        DatasetClass = config.DATASET_CLASS
-        dataset_kwargs = dict((key.lower(), val) for key, val in config.DATASET.items())
-        train_dataset = DatasetClass(
-            subset="train",
-            **dataset_kwargs,
-        )
-        config_dict['CLASSES'] = train_dataset.classes
-
-    with file_io.File(os.path.join(output_dir, file_name), mode='w') as outfile:
-        yaml.dump(config_dict, outfile, default_flow_style=False, Dumper=Dumper)
-
-    return file_path
-
-
 def save_yaml(output_dir, config):
-    """Save two yaml files.
-
-    1. 'config.yaml' is duplication of python config file as yaml.
-    2. 'meta.yaml' for application. The yaml's keys defined by `PARAMS_FOR_EXPORT`.
-    """
-
+    """Save yaml file 'meta.yaml' for application. Keys are defined by `PARAMS_FOR_EXPORT`."""
     if not file_io.exists(output_dir):
         file_io.makedirs(output_dir)
 
-    config_yaml_path = _save_config_yaml(output_dir, config)
     meta_yaml_path = _save_meta_yaml(output_dir, config)
 
-    return config_yaml_path, meta_yaml_path
-
-
-def _load_yaml(config_file):
-    with file_io.File(config_file) as config_file_stream:
-        config = yaml.load(config_file_stream, Loader=yaml.Loader)
-
-    # use only upper key.
-    keys = [key for key in config.keys() if key.isupper()]
-    config_dict = {key: config[key] for key in keys}
-    config = SmartDict(config_dict)
-    return config
+    return meta_yaml_path
 
 
 def load_from_experiment():

--- a/docs/specification/config.md
+++ b/docs/specification/config.md
@@ -3,7 +3,6 @@
 Go to section:
 
 * [Config](#config)
-* [Config yaml](#config-yaml)
 * [Meta yaml](#meta-yaml)
 
 # Config
@@ -47,17 +46,6 @@ Go to section:
 |DATASET.AUGMENTOR|Sequence|Sequence([...])|Sequence of augmentors.|○|||
 |DATASET.DATA_FORMAT|string|DATA_FORMAT|Data format. Normally same to DATA_FORMAT.|○|||
 |||||||
-
-# Config yaml
-Config yaml file has following Unstandard YAML [pyyaml](https://pyyaml.org/) defined tags:
-
-|tag|arg|python type|
-|---|---|---|
-|`!!python/name:`|module.cls|module.cls definition|
-|`!!python/object:`|module.cls|module.cls instance|
-
-You should remove these tags before using without python (pyyaml).
-i.e. [classification.yaml](https://github.com/blue-oil/blueoil/blob/master/blueoil/configs/example/classification.yaml)
 
 # Meta yaml
 The meta yaml file is created from config python file, that is only include `export` column parameter.

--- a/docs/usage/export.md
+++ b/docs/usage/export.md
@@ -1,11 +1,10 @@
 # Exporting model to proto buffer
-Exporting a trained model to proto buffer files and meta config yaml.
+Exporting a trained model to proto buffer files and meta yaml.
 
 In the case with `images` option, create each layer output value npy files in `export/{restore_path}/{image_size}/{image_name}/**.npy` for debug.
 
 * Load config file from saved experiment dir.
-* Export config file to yaml. See also [Config specification](../specification/config.md).
-  * `config.yaml` can be used for training and evaluation in python. i.e. [classification.yaml](https://github.com/blue-oil/blueoil/blob/master/blueoil/configs/example/classification.yaml) is exported from [classification.py](https://github.com/blue-oil/blueoil/blob/master/blueoil/configs/example/classification.py)
+* Export meta file to yaml. See also [Config specification](../specification/config.md).
   * `meta.yaml` include only few parameter for application such as demo. i.e. [classification_meta.yaml](https://github.com/blue-oil/blueoil/blob/master/blueoil/configs/example/classification_meta.yaml) is exported from [classification.py](https://github.com/blue-oil/blueoil/blob/master/blueoil/configs/example/classification.py)
 * Save the model protocol buffer files (tf) for DLK converter.
 * Output each layer npy files for DLK converter debug.
@@ -15,7 +14,7 @@ In the case with `images` option, create each layer output value npy files in `e
 # python3 blueoil/cmd/export.py -h
 Usage: export.py [OPTIONS]
 
-  Exporting a trained model to proto buffer files and meta config yaml.
+  Exporting a trained model to proto buffer files and meta yaml.
 
   In the case with `images` option, create each layer output value npy files
   in `export/{restore_path}/{image_size}/{image_name}/**.npy` for debug.

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -19,7 +19,7 @@ import os
 import pytest
 
 from blueoil import environment
-from blueoil.utils.config import _load_py, check_config, save_yaml
+from blueoil.utils.config import _load_py, check_config
 
 pytestmark = pytest.mark.usefixtures("set_test_environment")
 
@@ -45,63 +45,6 @@ def test_example_config():
         check_config(config, "inference")
 
 
-def test_example_classification_config_yaml():
-    """Test that export config and meta yaml from example classification config python."""
-
-    config_file = os.path.join("..", "blueoil", "configs", "example", "classification.py")
-
-    config = _load_py(config_file)
-
-    config_yaml = os.path.join("..", "blueoil", "configs", "example", "classification.yaml")
-
-    config_meta = os.path.join("..", "blueoil", "configs", "example", "classification_meta.yaml")
-
-    environment.init("test_example_classification_config_yaml")
-    saved_config, saved_meta = save_yaml(environment.EXPERIMENT_DIR, config)
-
-    print(saved_meta)
-    with open(config_yaml) as f:
-        expected = f.read()
-    with open(saved_config) as f:
-        data = f.read()
-        assert expected == data
-
-    with open(config_meta) as f:
-        expected = f.read()
-    with open(saved_meta) as f:
-        data = f.read()
-        assert expected == data
-
-
-def test_example_object_detection_config_yaml():
-    """Test that export config and meta yaml from example object_detection config python."""
-
-    config_file = os.path.join("..", "blueoil", "configs", "example", "object_detection.py")
-
-    config = _load_py(config_file)
-
-    config_yaml = os.path.join("..", "blueoil", "configs", "example", "object_detection.yaml")
-
-    config_meta = os.path.join("..", "blueoil", "configs", "example", "object_detection_meta.yaml")
-
-    environment.init("test_example_object_detection_config_yaml")
-    saved_config, saved_meta = save_yaml(environment.EXPERIMENT_DIR, config)
-
-    with open(config_yaml) as f:
-        expected = f.read()
-    with open(saved_config) as f:
-        data = f.read()
-        assert expected == data
-
-    with open(config_meta) as f:
-        expected = f.read()
-    with open(saved_meta) as f:
-        data = f.read()
-        assert expected == data
-
-
 if __name__ == '__main__':
     test_core_configs()
     test_example_config()
-    test_example_classification_config_yaml()
-    test_example_object_detection_config_yaml()


### PR DESCRIPTION
The `config.yaml` file is not a useful part of the pipeline, as far as I know. There is already the `config.py` file, which contains the same information. So, code for saving and loading a `config.yaml` is not necessary. This is stated in https://github.com/blue-oil/blueoil/issues/1224. A second point is that loading the `config.yaml` can cause error https://github.com/blue-oil/blueoil/pull/1110. So this PR would also resolve that problem.

After modifying the code, I tried training, exporting, and converting. All seemed to run fine. No `config.yaml` appears.

p.s. in the `save_yaml` function, I just remove the `config.yaml` part, not the `meta.yaml` part.