### PR TITLE
Fix PascalVOC dataset loader to accept float bndbox

### DIFF
--- a/blueoil/datasets/pascalvoc_base.py
+++ b/blueoil/datasets/pascalvoc_base.py
@@ -129,10 +129,10 @@ class PascalvocBase(ObjectDetectionBase):
             for e in list(obj):
                 if e.tag == "bndbox":
                     # subtract 1 to make boxes 0-based coordinate.
-                    ymin = int(e.find("ymin").text) - 1
-                    xmin = int(e.find("xmin").text) - 1
-                    ymax = int(e.find("ymax").text) - 1
-                    xmax = int(e.find("xmax").text) - 1
+                    ymin = float(e.find("ymin").text) - 1
+                    xmin = float(e.find("xmin").text) - 1
+                    ymax = float(e.find("ymax").text) - 1
+                    xmax = float(e.find("xmax").text) - 1
 
                     w = xmax - xmin
                     h = ymax - ymin

--- a/tests/unit/datasets_tests/test_pascalvoc.py
+++ b/tests/unit/datasets_tests/test_pascalvoc.py
@@ -29,7 +29,7 @@ def test_pascalvoc_2007():
     assert dataset.available_subsets == ['train', 'validation', 'test', 'train_validation']
     assert dataset._files_and_annotations() == (
         ['unit/fixtures/datasets/PASCALVOC_2007/VOCdevkit/VOC2007/JPEGImages/000085.jpg'],
-        [[[21, 69, 232, 257, 14], [337, 11, 162, 187, 14]]]
+        [[[5, 103, 212, 174, 8], [21, 69, 232, 257, 14]]]
     )
 
 
@@ -51,7 +51,7 @@ def test_pascalvoc_2007_2012():
         'unit/fixtures/datasets/PASCALVOC_2007/VOCdevkit/VOC2007/JPEGImages/000085.jpg',
         'unit/fixtures/datasets/PASCALVOC_2012/VOCdevkit/VOC2012/JPEGImages/2012_002012.jpg'
     ]
-    assert dataset.annotations == [[[21, 69, 232, 257, 14], [337, 11, 162, 187, 14]],
+    assert dataset.annotations == [[[5, 103, 212, 174, 8], [21, 69, 232, 257, 14]],
                                    [[190, 67, 145, 307, 14]]]
 
 
@@ -64,7 +64,7 @@ def test_pascalvoccustom():
     assert dataset.available_subsets == available_subsets
     assert dataset._files_and_annotations() == (
         ['unit/fixtures/datasets/PASCALVOC_2007/VOCdevkit/VOC2007/JPEGImages/000085.jpg'],
-        [[[21, 69, 232, 257, 0], [337, 11, 162, 187, 0]]])
+        [[[21, 69, 232, 257, 0]]])
 
     classes = ['person']
     available_subsets = ['train', 'validation', 'train_validation']

--- a/tests/unit/fixtures/datasets/PASCALVOC_2007/VOCdevkit/VOC2007/Annotations/000085.xml
+++ b/tests/unit/fixtures/datasets/PASCALVOC_2007/VOCdevkit/VOC2007/Annotations/000085.xml
@@ -21,7 +21,7 @@
 		<name>chair</name>
 		<pose>Unspecified</pose>
 		<truncated>1</truncated>
-		<difficult>1</difficult>
+		<difficult>0</difficult>
 		<bndbox>
 			<xmin>6</xmin>
 			<ymin>104</ymin>
@@ -47,17 +47,17 @@
 		<truncated>1</truncated>
 		<difficult>0</difficult>
 		<bndbox>
-			<xmin>22</xmin>
-			<ymin>70</ymin>
-			<xmax>254</xmax>
-			<ymax>327</ymax>
+			<xmin>22.</xmin>
+			<ymin>70.</ymin>
+			<xmax>254.</xmax>
+			<ymax>327.</ymax>
 		</bndbox>
 	</object>
 	<object>
 		<name>person</name>
 		<pose>Unspecified</pose>
 		<truncated>1</truncated>
-		<difficult>0</difficult>
+		<difficult>1</difficult>
 		<bndbox>
 			<xmin>338</xmin>
 			<ymin>12</ymin>

--- a/tests/unit/fixtures/datasets/PASCALVOC_2012/VOCdevkit/VOC2012/Annotations/2012_002012.xml
+++ b/tests/unit/fixtures/datasets/PASCALVOC_2012/VOCdevkit/VOC2012/Annotations/2012_002012.xml
@@ -17,10 +17,10 @@
 			<walking>0</walking>
 		</actions>
 		<bndbox>
-			<xmax>336</xmax>
-			<xmin>191</xmin>
-			<ymax>375</ymax>
-			<ymin>68</ymin>
+			<xmax>336.</xmax>
+			<xmin>191.</xmin>
+			<ymax>375.</ymax>
+			<ymin>68.</ymin>
 		</bndbox>
 		<difficult>0</difficult>
 		<pose>Unspecified</pose>


### PR DESCRIPTION
## What this patch does to fix the issue.
- Fix PascalVOC dataset loader to accept float bounding box
- Modify PascalVOC dataset unit test to coverage floating point and other class (not just person class)
## Link to any relevant issues or pull requests.
Closes #1226 