### PR TITLE
Fix sign function to return only 1 and -1

### DIFF
--- a/blueoil/converter/core/operators.py
+++ b/blueoil/converter/core/operators.py
@@ -743,14 +743,14 @@ class BinaryMeanScalingQuantizer(Quantizer):
     def run_forward(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data))
-        self._data = np.sign(in_data)
+        self._data = np.where((in_data >=0), 1, -1)
 
         return self._data * self._scaling_factor
 
     def run_forward_no_scaling_factor(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data))
-        self._data = np.sign(in_data)
+        self._data = np.where((in_data >=0), 1, -1)
 
         return self._data
 
@@ -2442,7 +2442,7 @@ class BinaryChannelWiseMeanScalingQuantizer(Quantizer):
     def run_forward(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data), axis=(1, 2, 3)).astype(np.float32)
-        self._data = np.sign(in_data)
+        self._data = np.where((in_data >=0), 1, -1)
 
         scaling = copy.deepcopy(self._scaling_factor)
         extra_dims = tuple(np.ones((len(self._data.shape) - len(scaling.shape)), dtype=np.int32))
@@ -2453,7 +2453,7 @@ class BinaryChannelWiseMeanScalingQuantizer(Quantizer):
     def run_forward_no_scaling_factor(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data), axis=(1, 2, 3)).astype(np.float32)
-        self._data = np.sign(in_data)
+        self._data = np.where((in_data >=0), 1, -1)
         return self._data
 
     def binarizer(self, data: np.ndarray) -> np.ndarray:

--- a/blueoil/converter/core/operators.py
+++ b/blueoil/converter/core/operators.py
@@ -743,14 +743,14 @@ class BinaryMeanScalingQuantizer(Quantizer):
     def run_forward(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data))
-        self._data = np.where((in_data >=0), 1, -1)
+        self._data = np.where((in_data >= 0), 1.0, -1.0)
 
         return self._data * self._scaling_factor
 
     def run_forward_no_scaling_factor(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data))
-        self._data = np.where((in_data >=0), 1, -1)
+        self._data = np.where((in_data >= 0), 1.0, -1.0)
 
         return self._data
 
@@ -2442,7 +2442,7 @@ class BinaryChannelWiseMeanScalingQuantizer(Quantizer):
     def run_forward(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data), axis=(1, 2, 3)).astype(np.float32)
-        self._data = np.where((in_data >=0), 1, -1)
+        self._data = np.where((in_data >= 0), 1.0, -1.0)
 
         scaling = copy.deepcopy(self._scaling_factor)
         extra_dims = tuple(np.ones((len(self._data.shape) - len(scaling.shape)), dtype=np.int32))
@@ -2453,7 +2453,7 @@ class BinaryChannelWiseMeanScalingQuantizer(Quantizer):
     def run_forward_no_scaling_factor(self) -> np.ndarray:
         in_data = self.input_ops['input'].data
         self._scaling_factor = np.mean(np.abs(in_data), axis=(1, 2, 3)).astype(np.float32)
-        self._data = np.where((in_data >=0), 1, -1)
+        self._data = np.where((in_data >= 0), 1.0, -1.0)
         return self._data
 
     def binarizer(self, data: np.ndarray) -> np.ndarray:

--- a/blueoil/quantizations/binary.py
+++ b/blueoil/quantizations/binary.py
@@ -87,7 +87,7 @@ def binary_channel_wise_mean_scaling_quantizer(
         scaling_factor = tf.reduce_mean(tf.abs(x), axis=[0, 1, 2])
         # TODO(wakisaka): tensorflow raise error.
         # tf.compat.v1.summary.histogram("scaling_factor", scaling_factor)
-        quantized = tf.sign(x) * scaling_factor
+        quantized = tf.where_v2((x >= 0), 1, -1) * scaling_factor
         return quantized
 
     return _forward
@@ -160,6 +160,6 @@ def binary_mean_scaling_quantizer(
 
         """
         expectation = tf.reduce_mean(tf.abs(x))
-        return tf.sign(x) * expectation
+        return tf.where_v2((x >= 0), 1, -1) * expectation
 
     return _forward

--- a/blueoil/quantizations/binary.py
+++ b/blueoil/quantizations/binary.py
@@ -87,7 +87,7 @@ def binary_channel_wise_mean_scaling_quantizer(
         scaling_factor = tf.reduce_mean(tf.abs(x), axis=[0, 1, 2])
         # TODO(wakisaka): tensorflow raise error.
         # tf.compat.v1.summary.histogram("scaling_factor", scaling_factor)
-        quantized = tf.where_v2((x >= 0), 1, -1) * scaling_factor
+        quantized = tf.where_v2((x >= 0), 1.0, -1.0) * scaling_factor
         return quantized
 
     return _forward
@@ -160,6 +160,6 @@ def binary_mean_scaling_quantizer(
 
         """
         expectation = tf.reduce_mean(tf.abs(x))
-        return tf.where_v2((x >= 0), 1, -1) * expectation
+        return tf.where_v2((x >= 0), 1.0, -1.0) * expectation
 
     return _forward


### PR DESCRIPTION
## What this patch does to fix the issue.
We assume the value from quantization can be only `1` or `-1`. If not, it can cause inference result mismatch.
This PR implemented a custom sign function. The only difference from `tf.sign` and `np.sign` is `sign(0) = 1` instead of 0. 

## Link to any relevant issues or pull requests.
Closes #1201 #1234 