### PR TITLE
Version up docker image for deploying docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             - html
   deploy:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:14.15.4
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Firebase is not avaiable with Node.js 8.