### PR TITLE
Fix license texts for third-party code

### DIFF
--- a/blueoil/common.py
+++ b/blueoil/common.py
@@ -64,11 +64,6 @@ def get_color_map(length):
 # The colormap allows for a large number of quantization levels:
 # https://tinyurl.com/ybm3kpql
 
-# Referred from the following gist:
-# https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
-# Copyright 2019 Google LLC.
-# SPDX-License-Identifier: Apache-2.0
-
 # Changes:
 # 1. Vectorized the implementation using numpy
 # 2. Use numpy.modf to get integer and float parts

--- a/blueoil/data_augmentor.py
+++ b/blueoil/data_augmentor.py
@@ -601,12 +601,32 @@ def _random_erasing_in_box(image, box, probability, sl, sh, r1, content_type, me
     return image
 
 
+# RandomSampleCrop
+# Ref: https://github.com/amdegroot/ssd.pytorch/blob/master/utils/augmentations.py#L208
+#
+# MIT License
+# Copyright (c) 2017 Max deGroot, Ellis Brown
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 class SSDRandomCrop(data_processor.Processor):
     """SSD random crop.
-
-    References:
-        https://github.com/amdegroot/ssd.pytorch/blob/master/utils/augmentations.py#L208
-
     Args:
         min_crop_ratio (number): Minimum crop ratio for cropping the
     """

--- a/blueoil/metrics/mean_average_precision.py
+++ b/blueoil/metrics/mean_average_precision.py
@@ -25,6 +25,20 @@ from tensorflow.python.ops import metrics_impl, variable_scope
 # ===========================================================================
 # Average precision computations on tensorflow
 # Ref: https://github.com/balancap/SSD-Tensorflow/blob/master/tf_extended/metrics.py
+#
+# Copyright 2017 Paul Balanca. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # ===========================================================================
 def average_precision(
         num_gt_boxes,

--- a/blueoil/turbo_color_map.py
+++ b/blueoil/turbo_color_map.py
@@ -1,19 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright 2020 The Blueoil Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
-
 # Colormap table taken from the following gist:
 # https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
 # Copyright 2019 Google LLC.


### PR DESCRIPTION
## What this patch does to fix the issue.
- `blueoil/common.py`: remove unnecessary comment
- `blueoil/data_augmentor.py`: add copyright info for third-party code
- `blueoil/metrics/mean_average_precision.py`: add copyright info for third-party code
- `blueoil/turbo_color_map.py`: remove Blueoil's copyright because whole the file comes from third-party code